### PR TITLE
refactor: use & borrowing for move_history instead of clones

### DIFF
--- a/src/pieces/bishop.rs
+++ b/src/pieces/bishop.rs
@@ -11,7 +11,7 @@ impl Movable for Bishop {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: Vec<(Option<PieceType>, String)>,
+        _move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
 
@@ -167,13 +167,13 @@ impl Position for Bishop {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         // if the king is checked we clean all the position not resolving the check
         impossible_positions_king_checked(
             coordinates,
-            Self::piece_move(coordinates, color, board, false, move_history.clone()),
+            Self::piece_move(coordinates, color, board, false, move_history),
             board,
             color,
             move_history,
@@ -183,7 +183,7 @@ impl Position for Bishop {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }
@@ -251,7 +251,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -306,7 +306,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -375,7 +375,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -424,7 +424,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions = vec![vec![4, 4]];
         right_positions.sort();
@@ -433,7 +433,7 @@ mod tests {
             [5, 5],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -484,7 +484,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions: Vec<Vec<i8>> = vec![];
         right_positions.sort();
@@ -493,7 +493,7 @@ mod tests {
             [5, 6],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -544,7 +544,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions: Vec<Vec<i8>> = vec![vec![2, 6], vec![3, 7]];
         right_positions.sort();
@@ -553,7 +553,7 @@ mod tests {
             [1, 5],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();

--- a/src/pieces/king.rs
+++ b/src/pieces/king.rs
@@ -12,7 +12,7 @@ impl Movable for King {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: Vec<(Option<PieceType>, String)>,
+        _move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
         let y = coordinates[0];
@@ -45,11 +45,11 @@ impl Position for King {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
         is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
-        let checked_cells = get_all_protected_cells(board, color, move_history.clone());
+        let checked_cells = get_all_protected_cells(board, color, move_history);
 
         let rook_big_castle_x = 0;
         let rook_small_castle_x = 7;
@@ -57,14 +57,14 @@ impl Position for King {
         let king_line = if color == PieceColor::White { 7 } else { 0 };
 
         // We check the condition for small and big castling
-        if !did_piece_already_move(&move_history, (Some(PieceType::King), [king_line, king_x]))
+        if !did_piece_already_move(move_history, (Some(PieceType::King), [king_line, king_x]))
             && !is_king_checked
         {
             // We check if there is no pieces between tower and king
 
             // Big castle check
             if !did_piece_already_move(
-                &move_history,
+                move_history,
                 (Some(PieceType::Rook), [king_line, rook_big_castle_x]),
             ) && King::check_castling_condition(board, color, 0, 3, &checked_cells)
             {
@@ -72,7 +72,7 @@ impl Position for King {
             }
             // Small castle check
             if !did_piece_already_move(
-                &move_history,
+                move_history,
                 (Some(PieceType::Rook), [king_line, rook_small_castle_x]),
             ) && King::check_castling_condition(board, color, 5, 7, &checked_cells)
             {
@@ -97,7 +97,7 @@ impl Position for King {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }
@@ -208,7 +208,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            King::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -269,7 +269,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            King::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -330,7 +330,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            King::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -391,7 +391,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([7, 4], PieceColor::White, board.board, vec![], false);
+            King::authorized_positions([7, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -452,7 +452,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([0, 4], PieceColor::Black, board.board, vec![], false);
+            King::authorized_positions([0, 4], PieceColor::Black, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -513,7 +513,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([0, 4], PieceColor::Black, board.board, vec![], false);
+            King::authorized_positions([0, 4], PieceColor::Black, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -571,7 +571,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions = vec![vec![0, 5]];
         right_positions.sort();
@@ -580,7 +580,7 @@ mod tests {
             [0, 4],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -646,7 +646,7 @@ mod tests {
             [0, 4],
             PieceColor::Black,
             board.board,
-            vec![
+            &vec![
                 (Some(PieceType::Rook), "0747".to_string()),
                 (Some(PieceType::Pawn), "6252".to_string()),
                 (Some(PieceType::Rook), "4707".to_string()),

--- a/src/pieces/knight.rs
+++ b/src/pieces/knight.rs
@@ -10,7 +10,7 @@ impl Movable for Knight {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: Vec<(Option<PieceType>, String)>,
+        _move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = Vec::new();
 
@@ -51,12 +51,12 @@ impl Position for Knight {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         impossible_positions_king_checked(
             coordinates,
-            Self::piece_move(coordinates, color, board, false, move_history.clone()),
+            Self::piece_move(coordinates, color, board, false, move_history),
             board,
             color,
             move_history,
@@ -67,7 +67,7 @@ impl Position for Knight {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        _move_history: Vec<(Option<PieceType>, String)>,
+        _move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, _move_history)
     }
@@ -130,7 +130,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Knight::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            Knight::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -182,7 +182,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Knight::authorized_positions([7, 7], PieceColor::White, board.board, vec![], false);
+            Knight::authorized_positions([7, 7], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -231,7 +231,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions = vec![vec![7, 7]];
         right_positions.sort();
@@ -240,7 +240,7 @@ mod tests {
             [6, 5],
             PieceColor::White,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -291,7 +291,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions: Vec<Vec<i8>> = vec![];
         right_positions.sort();
@@ -300,7 +300,7 @@ mod tests {
             [6, 4],
             PieceColor::White,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -350,7 +350,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions: Vec<Vec<i8>> = vec![];
         right_positions.sort();
@@ -359,7 +359,7 @@ mod tests {
             [1, 4],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();

--- a/src/pieces/mod.rs
+++ b/src/pieces/mod.rs
@@ -22,7 +22,7 @@ impl PieceType {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
         is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         match self {
@@ -64,7 +64,7 @@ impl PieceType {
         piece_type: PieceType,
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         match piece_type {
             PieceType::Pawn => {
@@ -134,7 +134,7 @@ pub trait Movable {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>>;
 }
 
@@ -143,7 +143,7 @@ pub trait Position {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
         is_king_checked: bool,
     ) -> Vec<Vec<i8>>;
 
@@ -151,6 +151,6 @@ pub trait Position {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>>;
 }

--- a/src/pieces/pawn.rs
+++ b/src/pieces/pawn.rs
@@ -12,7 +12,7 @@ impl Movable for Pawn {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         // Pawns can only move in one direction depending of their color
         // -1 if they are white (go up) +1 if they are black (go down)
@@ -84,7 +84,7 @@ impl Movable for Pawn {
         }
 
         // We check for en passant
-        let latest_move = get_latest_move(&move_history);
+        let latest_move = get_latest_move(move_history);
 
         match latest_move {
             (Some(PieceType::Pawn), piece_move) => {
@@ -129,14 +129,14 @@ impl Position for Pawn {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         // If the king is not checked we get then normal moves
         // if the king is checked we clean all the position not resolving the check
         impossible_positions_king_checked(
             coordinates,
-            Self::piece_move(coordinates, color, board, false, move_history.clone()),
+            Self::piece_move(coordinates, color, board, false, move_history),
             board,
             color,
             move_history,
@@ -147,7 +147,7 @@ impl Position for Pawn {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }
@@ -204,7 +204,7 @@ mod tests {
             [4, 4],
             PieceColor::White,
             board.board,
-            vec![(None, "0000".to_string())],
+            &vec![(None, "0000".to_string())],
             false,
         );
         positions.sort();
@@ -242,7 +242,7 @@ mod tests {
             [6, 4],
             PieceColor::White,
             board.board,
-            vec![(None, "0000".to_string())],
+            &vec![(None, "0000".to_string())],
             false,
         );
         positions.sort();
@@ -289,7 +289,7 @@ mod tests {
             [1, 3],
             PieceColor::Black,
             board.board,
-            vec![(None, "0000".to_string())],
+            &vec![(None, "0000".to_string())],
             false,
         );
         positions.sort();
@@ -336,7 +336,7 @@ mod tests {
             [1, 3],
             PieceColor::Black,
             board.board,
-            vec![(None, "0000".to_string())],
+            &vec![(None, "0000".to_string())],
             false,
         );
         positions.sort();
@@ -374,7 +374,7 @@ mod tests {
             [3, 3],
             PieceColor::White,
             board.board,
-            vec![(Some(PieceType::Pawn), "1232".to_string())],
+            &vec![(Some(PieceType::Pawn), "1232".to_string())],
             false,
         );
         positions.sort();
@@ -412,7 +412,7 @@ mod tests {
             [4, 2],
             PieceColor::Black,
             board.board,
-            vec![(Some(PieceType::Pawn), "6343".to_string())],
+            &vec![(Some(PieceType::Pawn), "6343".to_string())],
             false,
         );
         positions.sort();
@@ -459,7 +459,7 @@ mod tests {
             [1, 1],
             PieceColor::Black,
             board.board,
-            vec![(Some(PieceType::Pawn), "6343".to_string())],
+            &vec![(Some(PieceType::Pawn), "6343".to_string())],
             false,
         );
         positions.sort();
@@ -500,7 +500,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions = vec![vec![3, 2]];
         right_positions.sort();
@@ -509,7 +509,7 @@ mod tests {
             [2, 3],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -551,7 +551,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions: Vec<Vec<i8>> = vec![];
         right_positions.sort();
@@ -560,7 +560,7 @@ mod tests {
             [2, 4],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -611,7 +611,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions: Vec<Vec<i8>> = vec![];
         right_positions.sort();
@@ -620,7 +620,7 @@ mod tests {
             [1, 5],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();

--- a/src/pieces/queen.rs
+++ b/src/pieces/queen.rs
@@ -11,7 +11,7 @@ impl Movable for Queen {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
 
@@ -21,14 +21,14 @@ impl Movable for Queen {
             color,
             board,
             allow_move_on_ally_positions,
-            _move_history.clone(),
+            move_history,
         ));
         positions.extend(Rook::piece_move(
             coordinates,
             color,
             board,
             allow_move_on_ally_positions,
-            _move_history,
+            move_history,
         ));
 
         cleaned_positions(positions)
@@ -40,12 +40,12 @@ impl Position for Queen {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         impossible_positions_king_checked(
             coordinates,
-            Self::piece_move(coordinates, color, board, false, move_history.clone()),
+            Self::piece_move(coordinates, color, board, false, move_history),
             board,
             color,
             move_history,
@@ -55,9 +55,9 @@ impl Position for Queen {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        _move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
-        Self::piece_move(coordinates, color, board, true, _move_history)
+        Self::piece_move(coordinates, color, board, true, move_history)
     }
 }
 
@@ -137,7 +137,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Queen::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -206,7 +206,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Queen::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -285,7 +285,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Queen::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -333,7 +333,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions = vec![vec![4, 4]];
         right_positions.sort();
@@ -342,7 +342,7 @@ mod tests {
             [5, 5],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -392,7 +392,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions: Vec<Vec<i8>> = vec![];
         right_positions.sort();
@@ -401,7 +401,7 @@ mod tests {
             [5, 6],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -452,7 +452,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions: Vec<Vec<i8>> = vec![vec![2, 6], vec![3, 7]];
         right_positions.sort();
@@ -461,7 +461,7 @@ mod tests {
             [1, 5],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();

--- a/src/pieces/rook.rs
+++ b/src/pieces/rook.rs
@@ -12,7 +12,7 @@ impl Movable for Rook {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: Vec<(Option<PieceType>, String)>,
+        _move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
         // Pawns can only move in one direction depending on their color
         let mut positions: Vec<Vec<i8>> = vec![];
@@ -170,14 +170,14 @@ impl Position for Rook {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         // If the king is not checked we get then normal moves
         // if the king is checked we clean all the position not resolving the check
         impossible_positions_king_checked(
             coordinates,
-            Self::piece_move(coordinates, color, board, false, move_history.clone()),
+            Self::piece_move(coordinates, color, board, false, move_history),
             board,
             color,
             move_history,
@@ -188,9 +188,9 @@ impl Position for Rook {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        _move_history: Vec<(Option<PieceType>, String)>,
+        move_history: &Vec<(Option<PieceType>, String)>,
     ) -> Vec<Vec<i8>> {
-        Self::piece_move(coordinates, color, board, true, _move_history)
+        Self::piece_move(coordinates, color, board, true, move_history)
     }
 }
 
@@ -257,7 +257,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Rook::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
         assert_eq!(right_positions, positions);
     }
@@ -311,7 +311,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Rook::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
         assert_eq!(right_positions, positions);
     }
@@ -371,7 +371,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Rook::authorized_positions([4, 4], PieceColor::White, board.board, vec![], false);
+            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -420,7 +420,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions = vec![vec![4, 2]];
         right_positions.sort();
@@ -429,7 +429,7 @@ mod tests {
             [5, 2],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -480,7 +480,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions: Vec<Vec<i8>> = vec![];
         right_positions.sort();
@@ -489,7 +489,7 @@ mod tests {
             [5, 3],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();
@@ -539,7 +539,7 @@ mod tests {
         board.set_board(custom_board);
 
         let is_king_checked =
-            is_getting_checked(board.board, board.player_turn, board.moves_history);
+            is_getting_checked(board.board, board.player_turn, &board.move_history);
 
         let mut right_positions: Vec<Vec<i8>> = vec![vec![2, 4], vec![3, 4]];
         right_positions.sort();
@@ -548,7 +548,7 @@ mod tests {
             [1, 4],
             PieceColor::Black,
             board.board,
-            vec![],
+            &vec![],
             is_king_checked,
         );
         positions.sort();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,7 +68,7 @@ pub fn is_vec_in_array(array: Vec<Vec<i8>>, element: [i8; 2]) -> bool {
 pub fn get_all_protected_cells(
     board: [[Option<(PieceType, PieceColor)>; 8]; 8],
     player_turn: PieceColor,
-    move_history: Vec<(Option<PieceType>, String)>,
+    move_history: &Vec<(Option<PieceType>, String)>,
 ) -> Vec<Vec<i8>> {
     let mut check_cells: Vec<Vec<i8>> = vec![];
     for i in 0..8i8 {
@@ -84,7 +84,7 @@ pub fn get_all_protected_cells(
                         piece_type,
                         piece_color,
                         board,
-                        move_history.clone(),
+                        move_history,
                     ));
                 }
             }
@@ -185,7 +185,7 @@ pub fn get_king_coordinates(
 pub fn is_getting_checked(
     board: [[Option<(PieceType, PieceColor)>; 8]; 8],
     player_turn: PieceColor,
-    move_history: Vec<(Option<PieceType>, String)>,
+    move_history: &Vec<(Option<PieceType>, String)>,
 ) -> bool {
     let coordinates = get_king_coordinates(board, player_turn);
 
@@ -204,7 +204,7 @@ pub fn impossible_positions_king_checked(
     positions: Vec<Vec<i8>>,
     board: [[Option<(PieceType, PieceColor)>; 8]; 8],
     color: PieceColor,
-    move_history: Vec<(Option<PieceType>, String)>,
+    move_history: &Vec<(Option<PieceType>, String)>,
 ) -> Vec<Vec<i8>> {
     let mut cleaned_position: Vec<Vec<i8>> = vec![];
     for position in positions {
@@ -226,7 +226,7 @@ pub fn impossible_positions_king_checked(
         if !is_getting_checked(
             new_board.board,
             new_board.player_turn,
-            new_board.moves_history,
+            &new_board.move_history,
         ) {
             cleaned_position.push(position)
         };


### PR DESCRIPTION
# use & instead of clones for move_history

## Description

The goal here is to optimise a bit the code to use less clones which are more costly than borrowing and less clean I guess

Fixes #31 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
