### PR TITLE
fix: line 8 for history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chess-tui"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Thomas Mauran"]
 license = "MIT"
 edition = "2021"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,10 +115,10 @@ pub fn convert_position_into_notation(position: String) -> String {
     let to_x = get_int_from_char(position.chars().nth(3));
 
     result += &col_to_letter(from_x);
-    result += &format!("{}", (8 - from_y) % 8).to_string();
+    result += &format!("{}", (8 - from_y) % 9).to_string();
     result += "-";
     result += &col_to_letter(to_x);
-    result += &format!("{}", (8 - to_y) % 8).to_string();
+    result += &format!("{}", (8 - to_y) % 9).to_string();
 
     result
 }
@@ -248,5 +248,20 @@ pub fn color_to_ratatui_enum(piece_color: Option<PieceColor>) -> Color {
         Some(PieceColor::Black) => Color::Black,
         Some(PieceColor::White) => Color::White,
         None => Color::Red,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::convert_position_into_notation;
+
+    #[test]
+    fn convert_position_into_notation_1() {
+        assert_eq!(convert_position_into_notation("7152".to_string()), "b1-c3")
+    }
+
+    #[test]
+    fn convert_position_into_notation_2() {
+        assert_eq!(convert_position_into_notation("0257".to_string()), "c8-h3")
     }
 }


### PR DESCRIPTION
# fix bug on line 8 behing 0 in the historic

## Description

The bug was pretty simple and displayed 0 instead of 8 when moving from or to the first row (going from top to bottom)

Fixes #36 

## How Has This Been Tested?

- [x] convert_position_into_notation_1
- [x] convert_position_into_notation_2

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
