### PR TITLE
Creates a much smaller final docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,7 @@ COPY ./ ./
 # Build your program for release
 RUN cargo build --release
 
-ENTRYPOINT [ "/target/release/chess-tui" ]
+FROM debian:bookworm-slim AS runner
+COPY --from=builder /target/release/chess-tui /usr/bin/chess-tui
+
+ENTRYPOINT [ "/usr/bin/chess-tui" ]


### PR DESCRIPTION
# Create a much smaller run docker image

## Description

The build docker image is over 1.5 GB, which is much larger than needed. This PR copies the built binary to a much smaller (80MB) image.

## Checklist:

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
- [ X] Any dependent changes have been merged and published in downstream modules
