### PR TITLE
fix: do not allow selecting a chess piece with a not authorized move

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -256,6 +256,16 @@ impl Board {
             self.promote_piece();
         } else if !self.is_checkmate && !self.is_draw {
             if !self.is_cell_selected() {
+                // Check if the piece on the cell can move before selecting it
+                let piece_color = get_piece_color(self.board, self.cursor_coordinates);
+                let piece_type = get_piece_type(self.board, self.cursor_coordinates);
+
+                let authorized_positions= 
+                    self.get_authorized_positions(piece_type, piece_color, self.cursor_coordinates);
+
+                if authorized_positions.is_empty() {
+                    return;
+                }
                 match get_piece_color(self.board, self.cursor_coordinates) {
                     Some(piece_color) => {
                         if piece_color == self.player_turn {


### PR DESCRIPTION
# Do not allow piece selection when there is no authorized moves
Update `select_cell` method to avoid selecting not authorized select

## Description

Especially for the first player, do not allow selecting a chess piece with a not authorized move.

Fixes # (#44 )

## How Has This Been Tested?

Start game and try to select not authorized piece as main pieces.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
