### PR TITLE
vim keyboard shortcuts, `cargo clippy` lints

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -266,15 +266,12 @@ impl Board {
                 if authorized_positions.is_empty() {
                     return;
                 }
-                match get_piece_color(self.board, self.cursor_coordinates) {
-                    Some(piece_color) => {
-                        if piece_color == self.player_turn {
-                            self.selected_coordinates = self.cursor_coordinates;
-                            self.old_cursor_position = self.cursor_coordinates;
-                            self.move_selected_piece_cursor(true, 1);
-                        }
+                if let Some(piece_color) = get_piece_color(self.board, self.cursor_coordinates) {
+                    if piece_color == self.player_turn {
+                        self.selected_coordinates = self.cursor_coordinates;
+                        self.old_cursor_position = self.cursor_coordinates;
+                        self.move_selected_piece_cursor(true, 1);
                     }
-                    _ => {}
                 }
             } else {
                 // We already selected a piece
@@ -312,12 +309,9 @@ impl Board {
             };
 
             let current_piece_color = get_piece_color(self.board, [to_y, to_x]);
-            match current_piece_color {
-                Some(piece_color) => {
-                    // we replace the piece by the new piece type
-                    self.board[to_y as usize][to_x as usize] = Some((new_piece, piece_color));
-                }
-                _ => {}
+            if let Some(piece_color) = current_piece_color {
+                // we replace the piece by the new piece type
+                self.board[to_y as usize][to_x as usize] = Some((new_piece, piece_color));
             }
         }
         self.is_promotion = false;
@@ -404,17 +398,14 @@ impl Board {
 
         for i in 0..8 {
             for j in 0..8 {
-                match self.board[i][j] {
-                    Some((piece_type, piece_color)) => {
-                        if piece_color == self.player_turn {
-                            possible_moves.extend(self.get_authorized_positions(
-                                Some(piece_type),
-                                Some(piece_color),
-                                [i as i8, j as i8],
-                            ))
-                        }
+                if let Some((piece_type, piece_color)) = self.board[i][j] {
+                    if piece_color == self.player_turn {
+                        possible_moves.extend(self.get_authorized_positions(
+                            Some(piece_type),
+                            Some(piece_color),
+                            [i as i8, j as i8],
+                        ))
                     }
-                    _ => {}
                 }
             }
         }

--- a/src/board.rs
+++ b/src/board.rs
@@ -667,7 +667,7 @@ impl Board {
         );
 
         // Bottom paragraph help text
-        let text = vec![Line::from("Press h for help").alignment(Alignment::Center)];
+        let text = vec![Line::from("Press ? for help").alignment(Alignment::Center)];
 
         let help_paragraph = Paragraph::new(text)
             .block(Block::new())

--- a/src/board.rs
+++ b/src/board.rs
@@ -717,7 +717,7 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        assert!(is_getting_checked(custom_board, PieceColor::White, &vec![]));
+        assert!(is_getting_checked(custom_board, PieceColor::White, &[]));
     }
 
     #[test]
@@ -762,11 +762,7 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        assert!(!is_getting_checked(
-            custom_board,
-            PieceColor::White,
-            &vec![]
-        ));
+        assert!(!is_getting_checked(custom_board, PieceColor::White, &[]));
     }
 
     #[test]
@@ -820,11 +816,7 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        assert!(!is_getting_checked(
-            custom_board,
-            PieceColor::Black,
-            &vec![]
-        ));
+        assert!(!is_getting_checked(custom_board, PieceColor::Black, &[]));
     }
 
     #[test]
@@ -887,11 +879,7 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        assert!(!is_getting_checked(
-            custom_board,
-            PieceColor::Black,
-            &vec![]
-        ));
+        assert!(!is_getting_checked(custom_board, PieceColor::Black, &[]));
     }
 
     #[test]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -15,16 +15,16 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
             }
         }
         // Counter handlers
-        KeyCode::Right => app.board.cursor_right(),
-        KeyCode::Left => app.board.cursor_left(),
-        KeyCode::Up => {
+        KeyCode::Right | KeyCode::Char('l') => app.board.cursor_right(),
+        KeyCode::Left | KeyCode::Char('h') => app.board.cursor_left(),
+        KeyCode::Up | KeyCode::Char('k') => {
             if app.show_home_menu {
                 app.menu_cursor_up()
             } else {
                 app.board.cursor_up()
             }
         }
-        KeyCode::Down => {
+        KeyCode::Down | KeyCode::Char('j') => {
             if app.show_home_menu {
                 app.menu_cursor_down()
             } else {
@@ -38,7 +38,7 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                 app.menu_select()
             }
         }
-        KeyCode::Char('h') => {
+        KeyCode::Char('?') => {
             if !app.show_home_menu {
                 app.show_help_popup = true
             }
@@ -48,7 +48,11 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
             app.show_help_popup = false;
         }
         KeyCode::Char('r') => app.restart(),
-        KeyCode::Esc => app.board.unselect_cell(),
+        KeyCode::Esc => {
+            app.board.unselect_cell();
+            app.show_credit_popup = false;
+            app.show_help_popup = false;
+        }
         // Other handlers you could add here.
         _ => {}
     }

--- a/src/pieces/bishop.rs
+++ b/src/pieces/bishop.rs
@@ -251,7 +251,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -306,7 +306,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -375,7 +375,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -433,7 +433,7 @@ mod tests {
             [5, 5],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -493,7 +493,7 @@ mod tests {
             [5, 6],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -553,7 +553,7 @@ mod tests {
             [1, 5],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();

--- a/src/pieces/bishop.rs
+++ b/src/pieces/bishop.rs
@@ -11,7 +11,7 @@ impl Movable for Bishop {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: &Vec<(Option<PieceType>, String)>,
+        _move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
 
@@ -167,7 +167,7 @@ impl Position for Bishop {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         // if the king is checked we clean all the position not resolving the check
@@ -183,7 +183,7 @@ impl Position for Bishop {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }

--- a/src/pieces/king.rs
+++ b/src/pieces/king.rs
@@ -12,7 +12,7 @@ impl Movable for King {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: &Vec<(Option<PieceType>, String)>,
+        _move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
         let y = coordinates[0];
@@ -45,7 +45,7 @@ impl Position for King {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
         is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
@@ -97,7 +97,7 @@ impl Position for King {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }
@@ -119,7 +119,7 @@ impl King {
         color: PieceColor,
         start: i8,
         end: i8,
-        checked_cells: &Vec<Vec<i8>>,
+        checked_cells: &[Vec<i8>],
     ) -> bool {
         let king_line = if color == PieceColor::White { 7 } else { 0 };
 
@@ -128,7 +128,7 @@ impl King {
         for i in start..=end {
             let new_coordinates = [king_line, i];
 
-            if is_vec_in_array(checked_cells.clone(), new_coordinates) {
+            if is_vec_in_array(checked_cells.to_owned().clone(), new_coordinates) {
                 valid_for_castling = false;
             }
             if (i == 7 || i == 0)

--- a/src/pieces/king.rs
+++ b/src/pieces/king.rs
@@ -134,9 +134,8 @@ impl King {
             if (i == 7 || i == 0)
                 && (get_piece_type(board, new_coordinates) != Some(PieceType::Rook)
                     || !is_cell_color_ally(board, new_coordinates, color))
+                || (i != 7 && i != 0 && get_piece_type(board, new_coordinates).is_some())
             {
-                valid_for_castling = false;
-            } else if i != 7 && i != 0 && get_piece_type(board, new_coordinates).is_some() {
                 valid_for_castling = false;
             }
         }

--- a/src/pieces/king.rs
+++ b/src/pieces/king.rs
@@ -207,7 +207,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            King::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -268,7 +268,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            King::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -329,7 +329,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            King::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -390,7 +390,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([7, 4], PieceColor::White, board.board, &vec![], false);
+            King::authorized_positions([7, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -451,7 +451,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([0, 4], PieceColor::Black, board.board, &vec![], false);
+            King::authorized_positions([0, 4], PieceColor::Black, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -512,7 +512,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            King::authorized_positions([0, 4], PieceColor::Black, board.board, &vec![], false);
+            King::authorized_positions([0, 4], PieceColor::Black, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -579,7 +579,7 @@ mod tests {
             [0, 4],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -645,7 +645,7 @@ mod tests {
             [0, 4],
             PieceColor::Black,
             board.board,
-            &vec![
+            &[
                 (Some(PieceType::Rook), "0747".to_string()),
                 (Some(PieceType::Pawn), "6252".to_string()),
                 (Some(PieceType::Rook), "4707".to_string()),

--- a/src/pieces/knight.rs
+++ b/src/pieces/knight.rs
@@ -10,7 +10,7 @@ impl Movable for Knight {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: &Vec<(Option<PieceType>, String)>,
+        _move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = Vec::new();
 
@@ -51,7 +51,7 @@ impl Position for Knight {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         impossible_positions_king_checked(
@@ -67,7 +67,7 @@ impl Position for Knight {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        _move_history: &Vec<(Option<PieceType>, String)>,
+        _move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, _move_history)
     }

--- a/src/pieces/knight.rs
+++ b/src/pieces/knight.rs
@@ -130,7 +130,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Knight::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            Knight::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -182,7 +182,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Knight::authorized_positions([7, 7], PieceColor::White, board.board, &vec![], false);
+            Knight::authorized_positions([7, 7], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -240,7 +240,7 @@ mod tests {
             [6, 5],
             PieceColor::White,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -300,7 +300,7 @@ mod tests {
             [6, 4],
             PieceColor::White,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -359,7 +359,7 @@ mod tests {
             [1, 4],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();

--- a/src/pieces/mod.rs
+++ b/src/pieces/mod.rs
@@ -22,7 +22,7 @@ impl PieceType {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
         is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         match self {
@@ -64,7 +64,7 @@ impl PieceType {
         piece_type: PieceType,
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         match piece_type {
             PieceType::Pawn => {
@@ -134,7 +134,7 @@ pub trait Movable {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>>;
 }
 
@@ -143,7 +143,7 @@ pub trait Position {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
         is_king_checked: bool,
     ) -> Vec<Vec<i8>>;
 
@@ -151,6 +151,6 @@ pub trait Position {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>>;
 }

--- a/src/pieces/pawn.rs
+++ b/src/pieces/pawn.rs
@@ -12,7 +12,7 @@ impl Movable for Pawn {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         // Pawns can only move in one direction depending of their color
         // -1 if they are white (go up) +1 if they are black (go down)
@@ -86,38 +86,35 @@ impl Movable for Pawn {
         // We check for en passant
         let latest_move = get_latest_move(move_history);
 
-        match latest_move {
-            (Some(PieceType::Pawn), piece_move) => {
-                let from_y = get_int_from_char(piece_move.chars().nth(0));
-                let from_x = get_int_from_char(piece_move.chars().nth(1));
-                let to_y = get_int_from_char(piece_move.chars().nth(2));
-                let to_x = get_int_from_char(piece_move.chars().nth(3));
+        if let (Some(PieceType::Pawn), piece_move) = latest_move {
+            let from_y = get_int_from_char(piece_move.chars().nth(0));
+            let from_x = get_int_from_char(piece_move.chars().nth(1));
+            let to_y = get_int_from_char(piece_move.chars().nth(2));
+            let to_x = get_int_from_char(piece_move.chars().nth(3));
 
-                let valid_y_start: i8;
-                let number_of_cells_move: i8;
+            let valid_y_start: i8;
+            let number_of_cells_move: i8;
 
-                if color == PieceColor::White {
-                    valid_y_start = 1;
-                    number_of_cells_move = to_y - from_y;
-                } else {
-                    valid_y_start = 6;
-                    number_of_cells_move = from_y - to_y;
-                };
+            if color == PieceColor::White {
+                valid_y_start = 1;
+                number_of_cells_move = to_y - from_y;
+            } else {
+                valid_y_start = 6;
+                number_of_cells_move = from_y - to_y;
+            };
 
-                // We check if the latest move was on the right start cell
-                // if it moved 2 cells
-                // and if the current pawn is next to this pawn latest position
-                if from_y == valid_y_start
-                    && number_of_cells_move == 2
-                    && y == to_y
-                    && (x == to_x - 1 || x == to_x + 1)
-                {
-                    let new_y = from_y + -direction;
-                    let new_x = from_x;
-                    positions.push([new_y, new_x].to_vec());
-                }
+            // We check if the latest move was on the right start cell
+            // if it moved 2 cells
+            // and if the current pawn is next to this pawn latest position
+            if from_y == valid_y_start
+                && number_of_cells_move == 2
+                && y == to_y
+                && (x == to_x - 1 || x == to_x + 1)
+            {
+                let new_y = from_y + -direction;
+                let new_x = from_x;
+                positions.push([new_y, new_x].to_vec());
             }
-            _ => {}
         }
 
         cleaned_positions(positions)
@@ -129,7 +126,7 @@ impl Position for Pawn {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         // If the king is not checked we get then normal moves
@@ -147,7 +144,7 @@ impl Position for Pawn {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }

--- a/src/pieces/pawn.rs
+++ b/src/pieces/pawn.rs
@@ -201,7 +201,7 @@ mod tests {
             [4, 4],
             PieceColor::White,
             board.board,
-            &vec![(None, "0000".to_string())],
+            &[(None, "0000".to_string())],
             false,
         );
         positions.sort();
@@ -239,7 +239,7 @@ mod tests {
             [6, 4],
             PieceColor::White,
             board.board,
-            &vec![(None, "0000".to_string())],
+            &[(None, "0000".to_string())],
             false,
         );
         positions.sort();
@@ -286,7 +286,7 @@ mod tests {
             [1, 3],
             PieceColor::Black,
             board.board,
-            &vec![(None, "0000".to_string())],
+            &[(None, "0000".to_string())],
             false,
         );
         positions.sort();
@@ -333,7 +333,7 @@ mod tests {
             [1, 3],
             PieceColor::Black,
             board.board,
-            &vec![(None, "0000".to_string())],
+            &[(None, "0000".to_string())],
             false,
         );
         positions.sort();
@@ -371,7 +371,7 @@ mod tests {
             [3, 3],
             PieceColor::White,
             board.board,
-            &vec![(Some(PieceType::Pawn), "1232".to_string())],
+            &[(Some(PieceType::Pawn), "1232".to_string())],
             false,
         );
         positions.sort();
@@ -409,7 +409,7 @@ mod tests {
             [4, 2],
             PieceColor::Black,
             board.board,
-            &vec![(Some(PieceType::Pawn), "6343".to_string())],
+            &[(Some(PieceType::Pawn), "6343".to_string())],
             false,
         );
         positions.sort();
@@ -456,7 +456,7 @@ mod tests {
             [1, 1],
             PieceColor::Black,
             board.board,
-            &vec![(Some(PieceType::Pawn), "6343".to_string())],
+            &[(Some(PieceType::Pawn), "6343".to_string())],
             false,
         );
         positions.sort();
@@ -506,7 +506,7 @@ mod tests {
             [2, 3],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -557,7 +557,7 @@ mod tests {
             [2, 4],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -617,7 +617,7 @@ mod tests {
             [1, 5],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();

--- a/src/pieces/queen.rs
+++ b/src/pieces/queen.rs
@@ -137,7 +137,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -206,7 +206,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -285,7 +285,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -342,7 +342,7 @@ mod tests {
             [5, 5],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -401,7 +401,7 @@ mod tests {
             [5, 6],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -461,7 +461,7 @@ mod tests {
             [1, 5],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();

--- a/src/pieces/queen.rs
+++ b/src/pieces/queen.rs
@@ -11,7 +11,7 @@ impl Movable for Queen {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
 
@@ -40,7 +40,7 @@ impl Position for Queen {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         impossible_positions_king_checked(
@@ -55,7 +55,7 @@ impl Position for Queen {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }

--- a/src/pieces/rook.rs
+++ b/src/pieces/rook.rs
@@ -12,7 +12,7 @@ impl Movable for Rook {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: &Vec<(Option<PieceType>, String)>,
+        _move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         // Pawns can only move in one direction depending on their color
         let mut positions: Vec<Vec<i8>> = vec![];
@@ -170,7 +170,7 @@ impl Position for Rook {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         // If the king is not checked we get then normal moves
@@ -188,7 +188,7 @@ impl Position for Rook {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &Vec<(Option<PieceType>, String)>,
+        move_history: &[(Option<PieceType>, String)],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }

--- a/src/pieces/rook.rs
+++ b/src/pieces/rook.rs
@@ -257,7 +257,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
         assert_eq!(right_positions, positions);
     }
@@ -311,7 +311,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
         assert_eq!(right_positions, positions);
     }
@@ -371,7 +371,7 @@ mod tests {
         right_positions.sort();
 
         let mut positions =
-            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &vec![], false);
+            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -429,7 +429,7 @@ mod tests {
             [5, 2],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -489,7 +489,7 @@ mod tests {
             [5, 3],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();
@@ -548,7 +548,7 @@ mod tests {
             [1, 4],
             PieceColor::Black,
             board.board,
-            &vec![],
+            &[],
             is_king_checked,
         );
         positions.sort();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -83,7 +83,7 @@ pub fn render_menu_ui(frame: &mut Frame, app: &App, main_area: Rect) {
     frame.render_widget(sub_title, main_layout_horizontal[1]);
 
     // Board block representing the full board div
-    let menu_items = vec!["Normal game", "Help", "Credits"];
+    let menu_items = ["Normal game", "Help", "Credits"];
     let mut menu_body: Vec<Line<'_>> = vec![];
 
     for i in 0..menu_items.len() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -86,14 +86,14 @@ pub fn render_menu_ui(frame: &mut Frame, app: &App, main_area: Rect) {
     let menu_items = ["Normal game", "Help", "Credits"];
     let mut menu_body: Vec<Line<'_>> = vec![];
 
-    for i in 0..menu_items.len() {
+    for (i, menu_item) in menu_items.iter().enumerate() {
         menu_body.push(Line::from(""));
         let mut text = if app.menu_cursor == i as u8 {
             "> ".to_string()
         } else {
             "".to_string()
         };
-        text.push_str(menu_items[i]);
+        text.push_str(menu_item);
         menu_body.push(Line::from(text))
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,7 +68,7 @@ pub fn is_vec_in_array(array: Vec<Vec<i8>>, element: [i8; 2]) -> bool {
 pub fn get_all_protected_cells(
     board: [[Option<(PieceType, PieceColor)>; 8]; 8],
     player_turn: PieceColor,
-    move_history: &Vec<(Option<PieceType>, String)>,
+    move_history: &[(Option<PieceType>, String)],
 ) -> Vec<Vec<i8>> {
     let mut check_cells: Vec<Vec<i8>> = vec![];
     for i in 0..8i8 {
@@ -138,7 +138,7 @@ pub fn get_int_from_char(ch: Option<char>) -> i8 {
 }
 
 pub fn get_latest_move(
-    move_history: &Vec<(Option<PieceType>, String)>,
+    move_history: &[(Option<PieceType>, String)],
 ) -> (Option<PieceType>, String) {
     if !move_history.is_empty() {
         return move_history[move_history.len() - 1].clone();
@@ -147,7 +147,7 @@ pub fn get_latest_move(
 }
 
 pub fn did_piece_already_move(
-    move_history: &Vec<(Option<PieceType>, String)>,
+    move_history: &[(Option<PieceType>, String)],
     original_piece: (Option<PieceType>, [i8; 2]),
 ) -> bool {
     for entry in move_history {
@@ -168,13 +168,10 @@ pub fn get_king_coordinates(
 ) -> [i8; 2] {
     for i in 0..8i32 {
         for j in 0..8i32 {
-            match board[i as usize][j as usize] {
-                Some((piece_type, piece_color)) => {
-                    if piece_type == PieceType::King && piece_color == player_turn {
-                        return [i as i8, j as i8];
-                    }
+            if let Some((piece_type, piece_color)) = board[i as usize][j as usize] {
+                if piece_type == PieceType::King && piece_color == player_turn {
+                    return [i as i8, j as i8];
                 }
-                None => {}
             }
         }
     }
@@ -185,7 +182,7 @@ pub fn get_king_coordinates(
 pub fn is_getting_checked(
     board: [[Option<(PieceType, PieceColor)>; 8]; 8],
     player_turn: PieceColor,
-    move_history: &Vec<(Option<PieceType>, String)>,
+    move_history: &[(Option<PieceType>, String)],
 ) -> bool {
     let coordinates = get_king_coordinates(board, player_turn);
 
@@ -204,12 +201,12 @@ pub fn impossible_positions_king_checked(
     positions: Vec<Vec<i8>>,
     board: [[Option<(PieceType, PieceColor)>; 8]; 8],
     color: PieceColor,
-    move_history: &Vec<(Option<PieceType>, String)>,
+    move_history: &[(Option<PieceType>, String)],
 ) -> Vec<Vec<i8>> {
     let mut cleaned_position: Vec<Vec<i8>> = vec![];
     for position in positions {
         // We create a new board
-        let mut new_board = Board::new(board, color, move_history.clone());
+        let mut new_board = Board::new(board, color, move_history.to_owned().clone());
 
         // We simulate the move
 


### PR DESCRIPTION
added vim-alike keyboard shortcuts: h, j, k, l and therefore changed help key to `?`. Also applied `clippy` lints.