### PR TITLE
Add ASCII mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{board::Board, constants::Pages};
+use crate::{board::Board, board::DisplayMode, constants::Pages};
 use std::error;
 
 /// Application result type.
@@ -66,12 +66,12 @@ impl App {
         if self.menu_cursor > 0 {
             self.menu_cursor -= 1
         } else {
-            self.menu_cursor = 3
+            self.menu_cursor = 4
         }
     }
 
     pub fn menu_cursor_down(&mut self) {
-        if self.menu_cursor < 3 {
+        if self.menu_cursor < 4 {
             self.menu_cursor += 1
         } else {
             self.menu_cursor = 0
@@ -88,8 +88,14 @@ impl App {
         match self.menu_cursor {
             0 => self.current_page = Pages::Solo,
             1 => self.current_page = Pages::Bot,
-            2 => self.current_page = Pages::Help,
-            3 => self.current_page = Pages::Credit,
+            2 => {
+                self.board.display_mode = match self.board.display_mode {
+                    DisplayMode::ASCII => DisplayMode::DEFAULT,
+                    DisplayMode::DEFAULT => DisplayMode::ASCII,
+                };
+            }
+            3 => self.current_page = Pages::Help,
+            4 => self.current_page = Pages::Credit,
             _ => {}
         }
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -102,7 +102,7 @@ impl Default for Board {
             consecutive_non_pawn_or_capture: 0,
             engine: None,
             is_game_against_bot: false,
-            display_mode: DisplayMode::ASCII,
+            display_mode: DisplayMode::DEFAULT,
         }
     }
 }
@@ -128,7 +128,7 @@ impl Board {
             consecutive_non_pawn_or_capture: 0,
             engine: None,
             is_game_against_bot: false,
-            display_mode: DisplayMode::ASCII,
+            display_mode: DisplayMode::DEFAULT,
         }
     }
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -17,6 +17,11 @@ use ratatui::{
 };
 use uci::Engine;
 
+pub enum DisplayMode {
+    DEFAULT,
+    ASCII,
+}
+
 pub struct Board {
     pub board: [[Option<(PieceType, PieceColor)>; 8]; 8],
     pub cursor_coordinates: [i8; 2],
@@ -32,6 +37,7 @@ pub struct Board {
     pub consecutive_non_pawn_or_capture: i32,
     pub engine: Option<Engine>,
     pub is_game_against_bot: bool,
+    pub display_mode: DisplayMode,
 }
 
 impl Default for Board {
@@ -96,6 +102,7 @@ impl Default for Board {
             consecutive_non_pawn_or_capture: 0,
             engine: None,
             is_game_against_bot: false,
+            display_mode: DisplayMode::ASCII,
         }
     }
 }
@@ -121,6 +128,7 @@ impl Board {
             consecutive_non_pawn_or_capture: 0,
             engine: None,
             is_game_against_bot: false,
+            display_mode: DisplayMode::ASCII,
         }
     }
 
@@ -778,7 +786,8 @@ impl Board {
                 let piece_type = get_piece_type(self.board, [i, j]);
 
                 let color_enum = color_to_ratatui_enum(piece_color);
-                let piece_enum = PieceType::piece_type_to_string_enum(piece_type);
+                let piece_enum =
+                    PieceType::piece_type_to_string_enum(piece_type, &self.display_mode);
 
                 // Place the pieces on the board
                 let paragraph = Paragraph::new(piece_enum)

--- a/src/board.rs
+++ b/src/board.rs
@@ -2,10 +2,9 @@ use crate::{
     constants::{BLACK, UNDEFINED_POSITION, WHITE},
     pieces::{PieceColor, PieceType},
     utils::{
-        col_to_letter, color_to_ratatui_enum, convert_notation_into_position,
-        convert_position_into_notation, did_piece_already_move, get_int_from_char,
-        get_king_coordinates, get_piece_color, get_piece_type, get_player_turn_in_modulo,
-        is_getting_checked, is_valid,
+        col_to_letter, convert_notation_into_position, convert_position_into_notation,
+        did_piece_already_move, get_cell_paragraph, get_int_from_char, get_king_coordinates,
+        get_piece_color, get_piece_type, get_player_turn_in_modulo, is_getting_checked, is_valid,
     },
 };
 use ratatui::{
@@ -788,40 +787,10 @@ impl Board {
                     frame.render_widget(cell.clone(), square);
                 }
 
-                // We check if the current king is getting checked
-
                 // Get piece and color
-                let piece_color = get_piece_color(self.board, [i, j]);
-                let piece_type = get_piece_type(self.board, [i, j]);
-                let piece_enum =
-                    PieceType::piece_type_to_string_enum(piece_type, &self.display_mode);
+                let paragraph = get_cell_paragraph(self, [i, j], square);
 
-                let paragraph = match self.display_mode {
-                    DisplayMode::DEFAULT => {
-                        let color_enum = color_to_ratatui_enum(piece_color);
-
-                        // Place the pieces on the board
-                        Paragraph::new(piece_enum).fg(color_enum)
-                    }
-                    DisplayMode::ASCII => {
-                        // Determine piece letter case
-                        let paragraph = match piece_color {
-                            // pieces belonging to the player on top will be lower case
-                            Some(PieceColor::Black) => Paragraph::new(piece_enum.to_lowercase()),
-                            // pieces belonging to the player on bottom will be upper case
-                            Some(PieceColor::White) => {
-                                Paragraph::new(piece_enum.to_uppercase().underlined())
-                            }
-                            // Pass through original value
-                            None => Paragraph::new(piece_enum),
-                        };
-
-                        // Place the pieces on the board
-                        paragraph.block(Block::new().padding(Padding::vertical(square.height / 2)))
-                    }
-                };
-
-                frame.render_widget(paragraph.alignment(Alignment::Center), square);
+                frame.render_widget(paragraph, square);
             }
         }
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -775,7 +775,16 @@ impl Board {
                     let cell = Block::default().bg(Color::LightGreen);
                     frame.render_widget(cell.clone(), square);
                 } else {
-                    let cell = Block::default().bg(cell_color);
+                    let mut cell = Block::default();
+                    cell = match self.display_mode {
+                        DisplayMode::DEFAULT => cell.bg(cell_color),
+                        DisplayMode::ASCII => match cell_color {
+                            WHITE => cell.bg(Color::White).fg(Color::Black),
+                            BLACK => cell.bg(Color::Black).fg(Color::White),
+                            _ => cell.bg(cell_color),
+                        },
+                    };
+
                     frame.render_widget(cell.clone(), square);
                 }
 
@@ -807,6 +816,7 @@ impl Board {
 
                         // Place the pieces on the board
                         Paragraph::new(piece_enum_case)
+                            .bold()
                             .block(Block::new().padding(Padding::vertical(square.height / 2)))
                     }
                 };

--- a/src/board.rs
+++ b/src/board.rs
@@ -785,15 +785,35 @@ impl Board {
                 let piece_color = get_piece_color(self.board, [i, j]);
                 let piece_type = get_piece_type(self.board, [i, j]);
 
-                let color_enum = color_to_ratatui_enum(piece_color);
-                let piece_enum =
-                    PieceType::piece_type_to_string_enum(piece_type, &self.display_mode);
+                let paragraph = match self.display_mode {
+                    DisplayMode::DEFAULT => {
+                        let color_enum = color_to_ratatui_enum(piece_color);
+                        let piece_enum =
+                            PieceType::piece_type_to_string_enum(piece_type, &self.display_mode);
 
-                // Place the pieces on the board
-                let paragraph = Paragraph::new(piece_enum)
-                    .alignment(Alignment::Center)
-                    .fg(color_enum);
-                frame.render_widget(paragraph, square);
+                        // Place the pieces on the board
+                        Paragraph::new(piece_enum).fg(color_enum)
+                    }
+                    DisplayMode::ASCII => {
+                        let piece_enum =
+                            PieceType::piece_type_to_string_enum(piece_type, &self.display_mode);
+
+                        // Determine piece letter case
+                        let piece_enum_case = match piece_color {
+                            // pieces belonging to the player on top will be lower case
+                            Some(PieceColor::Black) => piece_enum.to_lowercase(),
+                            // pieces belonging to the player on bottom will be upper case
+                            Some(PieceColor::White) => piece_enum.to_uppercase(),
+                            // Pass through original value
+                            None => String::from(piece_enum),
+                        };
+
+                        // Place the pieces on the board
+                        Paragraph::new(piece_enum_case)
+                    }
+                };
+
+                frame.render_widget(paragraph.alignment(Alignment::Center), square);
             }
         }
     }

--- a/src/board.rs
+++ b/src/board.rs
@@ -807,6 +807,7 @@ impl Board {
 
                         // Place the pieces on the board
                         Paragraph::new(piece_enum_case)
+                            .block(Block::new().padding(Padding::vertical(square.height / 2)))
                     }
                 };
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -784,20 +784,17 @@ impl Board {
                 // Get piece and color
                 let piece_color = get_piece_color(self.board, [i, j]);
                 let piece_type = get_piece_type(self.board, [i, j]);
+                let piece_enum =
+                    PieceType::piece_type_to_string_enum(piece_type, &self.display_mode);
 
                 let paragraph = match self.display_mode {
                     DisplayMode::DEFAULT => {
                         let color_enum = color_to_ratatui_enum(piece_color);
-                        let piece_enum =
-                            PieceType::piece_type_to_string_enum(piece_type, &self.display_mode);
 
                         // Place the pieces on the board
                         Paragraph::new(piece_enum).fg(color_enum)
                     }
                     DisplayMode::ASCII => {
-                        let piece_enum =
-                            PieceType::piece_type_to_string_enum(piece_type, &self.display_mode);
-
                         // Determine piece letter case
                         let piece_enum_case = match piece_color {
                             // pieces belonging to the player on top will be lower case

--- a/src/board.rs
+++ b/src/board.rs
@@ -805,19 +805,19 @@ impl Board {
                     }
                     DisplayMode::ASCII => {
                         // Determine piece letter case
-                        let piece_enum_case = match piece_color {
+                        let paragraph = match piece_color {
                             // pieces belonging to the player on top will be lower case
-                            Some(PieceColor::Black) => piece_enum.to_lowercase(),
+                            Some(PieceColor::Black) => Paragraph::new(piece_enum.to_lowercase()),
                             // pieces belonging to the player on bottom will be upper case
-                            Some(PieceColor::White) => piece_enum.to_uppercase(),
+                            Some(PieceColor::White) => {
+                                Paragraph::new(piece_enum.to_uppercase().underlined())
+                            }
                             // Pass through original value
-                            None => String::from(piece_enum),
+                            None => Paragraph::new(piece_enum),
                         };
 
                         // Place the pieces on the board
-                        Paragraph::new(piece_enum_case)
-                            .bold()
-                            .block(Block::new().padding(Padding::vertical(square.height / 2)))
+                        paragraph.block(Block::new().padding(Padding::vertical(square.height / 2)))
                     }
                 };
 

--- a/src/pieces/bishop.rs
+++ b/src/pieces/bishop.rs
@@ -1,4 +1,5 @@
 use super::{Movable, PieceColor, PieceType, Position};
+use crate::board::DisplayMode;
 use crate::utils::{
     cleaned_positions, get_piece_color, impossible_positions_king_checked, is_cell_color_ally,
     is_piece_opposite_king, is_valid,
@@ -190,14 +191,19 @@ impl Position for Bishop {
 }
 
 impl Bishop {
-    pub fn to_string() -> &'static str {
-        "\
+    pub fn to_string(display_mode: &DisplayMode) -> &'static str {
+        match display_mode {
+            DisplayMode::DEFAULT => {
+                "\
     \n\
        ⭘\n\
       █✝█\n\
       ███\n\
     ▗█████▖\n\
     "
+            }
+            DisplayMode::ASCII => "B",
+        }
     }
 }
 

--- a/src/pieces/king.rs
+++ b/src/pieces/king.rs
@@ -1,9 +1,9 @@
 use super::{Movable, PieceColor, PieceType, Position};
+use crate::board::DisplayMode;
 use crate::utils::{
     cleaned_positions, did_piece_already_move, get_all_protected_cells, get_piece_type,
     is_cell_color_ally, is_valid, is_vec_in_array,
 };
-
 pub struct King;
 
 impl Movable for King {
@@ -104,14 +104,19 @@ impl Position for King {
 }
 
 impl King {
-    pub fn to_string() -> &'static str {
-        "\
+    pub fn to_string(display_mode: &DisplayMode) -> &'static str {
+        match display_mode {
+            DisplayMode::DEFAULT => {
+                "\
       ✚\n\
     ▞▀▄▀▚\n\
     ▙▄█▄▟\n\
     ▐███▌\n\
    ▗█████▖\n\
     "
+            }
+            DisplayMode::ASCII => "K",
+        }
     }
 
     // Check if nothing is in between the king and a rook and if none of those cells are getting checked

--- a/src/pieces/knight.rs
+++ b/src/pieces/knight.rs
@@ -1,4 +1,5 @@
 use super::{Movable, PieceColor, PieceType, Position};
+use crate::board::DisplayMode;
 use crate::utils::{
     cleaned_positions, impossible_positions_king_checked, is_cell_color_ally, is_valid,
 };
@@ -74,14 +75,19 @@ impl Position for Knight {
 }
 
 impl Knight {
-    pub fn to_string() -> &'static str {
-        "\
+    pub fn to_string(display_mode: &DisplayMode) -> &'static str {
+        match display_mode {
+            DisplayMode::DEFAULT => {
+                "\
     \n\
     ▟▛██▙\n\
    ▟█████\n\
    ▀▀▟██▌\n\
     ▟████\n\
     "
+            }
+            DisplayMode::ASCII => "N",
+        }
     }
 }
 

--- a/src/pieces/mod.rs
+++ b/src/pieces/mod.rs
@@ -137,12 +137,12 @@ impl PieceType {
         display_mode: &DisplayMode,
     ) -> &'static str {
         match piece_type {
-            Some(PieceType::Queen) => Queen::to_string(&display_mode),
-            Some(PieceType::King) => King::to_string(&display_mode),
-            Some(PieceType::Rook) => Rook::to_string(&display_mode),
-            Some(PieceType::Bishop) => Bishop::to_string(&display_mode),
-            Some(PieceType::Knight) => Knight::to_string(&display_mode),
-            Some(PieceType::Pawn) => Pawn::to_string(&display_mode),
+            Some(PieceType::Queen) => Queen::to_string(display_mode),
+            Some(PieceType::King) => King::to_string(display_mode),
+            Some(PieceType::Rook) => Rook::to_string(display_mode),
+            Some(PieceType::Bishop) => Bishop::to_string(display_mode),
+            Some(PieceType::Knight) => Knight::to_string(display_mode),
+            Some(PieceType::Pawn) => Pawn::to_string(display_mode),
             None => " ",
         }
     }

--- a/src/pieces/mod.rs
+++ b/src/pieces/mod.rs
@@ -1,4 +1,5 @@
 use self::{bishop::Bishop, king::King, knight::Knight, pawn::Pawn, queen::Queen, rook::Rook};
+use super::board::DisplayMode;
 
 pub mod bishop;
 pub mod king;
@@ -131,14 +132,17 @@ impl PieceType {
         }
     }
 
-    pub fn piece_type_to_string_enum(piece_type: Option<PieceType>) -> &'static str {
+    pub fn piece_type_to_string_enum(
+        piece_type: Option<PieceType>,
+        display_mode: &DisplayMode,
+    ) -> &'static str {
         match piece_type {
-            Some(PieceType::Queen) => Queen::to_string(),
-            Some(PieceType::King) => King::to_string(),
-            Some(PieceType::Rook) => Rook::to_string(),
-            Some(PieceType::Bishop) => Bishop::to_string(),
-            Some(PieceType::Knight) => Knight::to_string(),
-            Some(PieceType::Pawn) => Pawn::to_string(),
+            Some(PieceType::Queen) => Queen::to_string(&display_mode),
+            Some(PieceType::King) => King::to_string(&display_mode),
+            Some(PieceType::Rook) => Rook::to_string(&display_mode),
+            Some(PieceType::Bishop) => Bishop::to_string(&display_mode),
+            Some(PieceType::Knight) => Knight::to_string(&display_mode),
+            Some(PieceType::Pawn) => Pawn::to_string(&display_mode),
             None => " ",
         }
     }

--- a/src/pieces/pawn.rs
+++ b/src/pieces/pawn.rs
@@ -1,4 +1,5 @@
 use super::{Movable, PieceColor, PieceType, Position};
+use crate::board::DisplayMode;
 use crate::utils::{
     cleaned_positions, get_int_from_char, get_latest_move, get_piece_color,
     impossible_positions_king_checked, is_cell_color_ally, is_valid,
@@ -151,14 +152,19 @@ impl Position for Pawn {
 }
 
 impl Pawn {
-    pub fn to_string() -> &'static str {
-        "\
+    pub fn to_string(display_mode: &DisplayMode) -> &'static str {
+        match display_mode {
+            DisplayMode::DEFAULT => {
+                "\
         \n\
         \n\
       ▟█▙\n\
       ▜█▛\n\
      ▟███▙\n\
     "
+            }
+            DisplayMode::ASCII => "P",
+        }
     }
 }
 

--- a/src/pieces/queen.rs
+++ b/src/pieces/queen.rs
@@ -1,5 +1,6 @@
 use super::rook::Rook;
 use super::{Movable, PieceColor, PieceType, Position};
+use crate::board::DisplayMode;
 use crate::pieces::bishop::Bishop;
 use crate::utils::{cleaned_positions, impossible_positions_king_checked};
 
@@ -62,14 +63,19 @@ impl Position for Queen {
 }
 
 impl Queen {
-    pub fn to_string() -> &'static str {
-        "\
+    pub fn to_string(display_mode: &DisplayMode) -> &'static str {
+        match display_mode {
+            DisplayMode::DEFAULT => {
+                "\
     \n\
 ◀█▟█▙█▶\n\
   ◥█◈█◤\n\
   ███\n\
 ▗█████▖\n\
     "
+            }
+            DisplayMode::ASCII => "Q",
+        }
     }
 }
 

--- a/src/pieces/rook.rs
+++ b/src/pieces/rook.rs
@@ -1,9 +1,9 @@
 use super::{Movable, PieceColor, PieceType, Position};
+use crate::board::DisplayMode;
 use crate::utils::{
     cleaned_positions, get_piece_color, impossible_positions_king_checked, is_cell_color_ally,
     is_piece_opposite_king, is_valid,
 };
-
 pub struct Rook;
 
 impl Movable for Rook {
@@ -195,14 +195,19 @@ impl Position for Rook {
 }
 
 impl Rook {
-    pub fn to_string() -> &'static str {
-        "\
+    pub fn to_string(display_mode: &DisplayMode) -> &'static str {
+        match display_mode {
+            DisplayMode::DEFAULT => {
+                "\
     \n\
     █▟█▙█\n\
     ▜███▛\n\
     ▐███▌\n\
    ▗█████▖\n\
     "
+            }
+            DisplayMode::ASCII => "R",
+        }
     }
 }
 

--- a/src/popups.rs
+++ b/src/popups.rs
@@ -116,7 +116,9 @@ pub fn render_promotion_popup(frame: &mut Frame, app: &App) {
         )
         .split(inner_popup_layout_vertical[1]);
 
-    let queen_p = Paragraph::new(Queen::to_string())
+    let display_mode = &app.board.display_mode;
+
+    let queen_p = Paragraph::new(Queen::to_string(display_mode))
         .block(Block::default())
         .alignment(Alignment::Center)
         .style(Style::default().bg(if app.board.promotion_cursor == 0 {
@@ -125,7 +127,7 @@ pub fn render_promotion_popup(frame: &mut Frame, app: &App) {
             Color::Reset // Set to the default background color when the condition is false
         }));
     frame.render_widget(queen_p, inner_popup_layout_horizontal[0]);
-    let rook_p = Paragraph::new(Rook::to_string())
+    let rook_p = Paragraph::new(Rook::to_string(display_mode))
         .block(Block::default())
         .alignment(Alignment::Center)
         .style(Style::default().bg(if app.board.promotion_cursor == 1 {
@@ -134,7 +136,7 @@ pub fn render_promotion_popup(frame: &mut Frame, app: &App) {
             Color::Reset // Set to the default background color when the condition is false
         }));
     frame.render_widget(rook_p, inner_popup_layout_horizontal[1]);
-    let bishop_p = Paragraph::new(Bishop::to_string())
+    let bishop_p = Paragraph::new(Bishop::to_string(display_mode))
         .block(Block::default())
         .alignment(Alignment::Center)
         .style(Style::default().bg(if app.board.promotion_cursor == 2 {
@@ -143,7 +145,7 @@ pub fn render_promotion_popup(frame: &mut Frame, app: &App) {
             Color::Reset // Set to the default background color when the condition is false
         }));
     frame.render_widget(bishop_p, inner_popup_layout_horizontal[2]);
-    let knight_p = Paragraph::new(Knight::to_string())
+    let knight_p = Paragraph::new(Knight::to_string(display_mode))
         .block(Block::default())
         .alignment(Alignment::Center)
         .style(Style::default().bg(if app.board.promotion_cursor == 3 {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,6 +9,7 @@ use ratatui::{
 
 use crate::{
     app::App,
+    board::DisplayMode,
     constants::{Pages, TITLE},
     pieces::PieceColor,
     popups::{
@@ -97,8 +98,23 @@ pub fn render_menu_ui(frame: &mut Frame, app: &App, main_area: Rect) {
         .block(Block::default());
     frame.render_widget(sub_title, main_layout_horizontal[1]);
 
+    // Determine the "display mode" text
+    let display_mode_menu = {
+        let display_mode = match app.board.display_mode {
+            DisplayMode::DEFAULT => "Default",
+            DisplayMode::ASCII => "ASCII",
+        };
+        format!("Display mode: {}", display_mode)
+    };
+
     // Board block representing the full board div
-    let menu_items = ["Normal game", "Play against a bot", "Help", "Credits"];
+    let menu_items = [
+        "Normal game",
+        "Play against a bot",
+        &display_mode_menu,
+        "Help",
+        "Credits",
+    ];
     let mut menu_body: Vec<Line<'_>> = vec![];
 
     for (i, menu_item) in menu_items.iter().enumerate() {


### PR DESCRIPTION
# Add ASCII mode

## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #58 

* A new option "Display mode" is added, selecting which will toggle the mode between "Default" and "ASCII".
* Using the GNU Chess notation for the pieces (e.g. R-Rook, N-Knight, K-King, etc.)
* Upper-case for the current player, and lower-case for the opponent.
* I haven't added the `--ascii` flag (suggested [here](https://github.com/thomas-mauran/chess-tui/issues/58#issuecomment-2014632510)). Please let me know if this flag will be desirable.

![image](https://github.com/thomas-mauran/chess-tui/assets/9392350/73cf17c2-a48b-406c-9805-943acdfe95cb)

![image](https://github.com/thomas-mauran/chess-tui/assets/9392350/c5394a0c-8a15-438c-b357-bef110afe48e)


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I have tested this manually, and all the existing test cases pass. However, I haven't written any tests for board rendering, since there doesn't seem to be any such existing tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
