### PR TITLE
docs: update Arch Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ pkgin install chess-tui
 
 **Arch Linux**
 
-On Arch Linux a PKGBUILD is available from the [AUR](https://aur.archlinux.org/packages/chess-tui). To install it, simply use an aur-helper:
+You can install from official repositories:
 
 ```
-paru -S chess-tui
+pacman -S chess-tui
 ```
 
 ### Features


### PR DESCRIPTION
`chess-tui` is now available in official repositories: https://archlinux.org/packages/extra/x86_64/chess-tui/
