### PR TITLE
Better History System

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -627,16 +627,19 @@ impl Board {
 
     fn is_latest_move_promotion(&self) -> bool {
         if let Some(last_move) = self.move_history.last() {
-            if let Some(piece_color) = get_piece_color(self.board, [last_move.to_y, last_move.to_x])
+            if let Some(piece_type_to) = get_piece_type(self.board, [last_move.to_y, last_move.to_x])
             {
-                let last_row = if piece_color == PieceColor::White {
-                    0
-                } else {
-                    7
-                };
+                if let Some(piece_color) = get_piece_color(self.board, [last_move.to_y, last_move.to_x])
+                {
+                    let last_row = if piece_color == PieceColor::White {
+                        0
+                    } else {
+                        7
+                    };
 
-                if last_move.to_y == last_row && last_move.piece_type == PieceType::Pawn {
-                    return true;
+                    if last_move.to_y == last_row && piece_type_to == PieceType::Pawn {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/pieces/bishop.rs
+++ b/src/pieces/bishop.rs
@@ -1,4 +1,4 @@
-use super::{Movable, PieceColor, PieceType, Position};
+use super::{Movable, PieceColor, PieceMove, PieceType, Position};
 use crate::board::DisplayMode;
 use crate::utils::{
     cleaned_positions, get_piece_color, impossible_positions_king_checked, is_cell_color_ally,
@@ -12,7 +12,7 @@ impl Movable for Bishop {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: &[(Option<PieceType>, String)],
+        _move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
 
@@ -168,7 +168,7 @@ impl Position for Bishop {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         // if the king is checked we clean all the position not resolving the check
@@ -184,7 +184,7 @@ impl Position for Bishop {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }

--- a/src/pieces/king.rs
+++ b/src/pieces/king.rs
@@ -1,4 +1,4 @@
-use super::{Movable, PieceColor, PieceType, Position};
+use super::{Movable, PieceColor, PieceMove, PieceType, Position};
 use crate::board::DisplayMode;
 use crate::utils::{
     cleaned_positions, did_piece_already_move, get_all_protected_cells, get_piece_type,
@@ -12,7 +12,7 @@ impl Movable for King {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: &[(Option<PieceType>, String)],
+        _move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
         let y = coordinates[0];
@@ -45,7 +45,7 @@ impl Position for King {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
         is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
@@ -97,7 +97,7 @@ impl Position for King {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }
@@ -154,7 +154,7 @@ impl King {
 mod tests {
     use crate::{
         board::Board,
-        pieces::{king::King, PieceColor, PieceType, Position},
+        pieces::{king::King, PieceColor, PieceMove, PieceType, Position},
         utils::is_getting_checked,
     };
 
@@ -652,9 +652,27 @@ mod tests {
             PieceColor::Black,
             board.board,
             &[
-                (Some(PieceType::Rook), "0747".to_string()),
-                (Some(PieceType::Pawn), "6252".to_string()),
-                (Some(PieceType::Rook), "4707".to_string()),
+                (PieceMove {
+                    piece_type: PieceType::Rook,
+                    from_y: 0,
+                    from_x: 7,
+                    to_y: 4,
+                    to_x: 7,
+                }),
+                (PieceMove {
+                    piece_type: PieceType::Pawn,
+                    from_y: 6,
+                    from_x: 2,
+                    to_y: 5,
+                    to_x: 2,
+                }),
+                (PieceMove {
+                    piece_type: PieceType::Rook,
+                    from_y: 4,
+                    from_x: 7,
+                    to_y: 0,
+                    to_x: 7,
+                }),
             ],
             false,
         );

--- a/src/pieces/knight.rs
+++ b/src/pieces/knight.rs
@@ -1,4 +1,4 @@
-use super::{Movable, PieceColor, PieceType, Position};
+use super::{Movable, PieceColor, PieceMove, PieceType, Position};
 use crate::board::DisplayMode;
 use crate::utils::{
     cleaned_positions, impossible_positions_king_checked, is_cell_color_ally, is_valid,
@@ -11,7 +11,7 @@ impl Movable for Knight {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: &[(Option<PieceType>, String)],
+        _move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = Vec::new();
 
@@ -52,7 +52,7 @@ impl Position for Knight {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         impossible_positions_king_checked(
@@ -68,7 +68,7 @@ impl Position for Knight {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        _move_history: &[(Option<PieceType>, String)],
+        _move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, _move_history)
     }

--- a/src/pieces/mod.rs
+++ b/src/pieces/mod.rs
@@ -23,7 +23,7 @@ impl PieceType {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
         is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         match self {
@@ -65,7 +65,7 @@ impl PieceType {
         piece_type: PieceType,
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         match piece_type {
             PieceType::Pawn => {
@@ -90,22 +90,22 @@ impl PieceType {
     }
 
     pub fn piece_to_utf_enum(
-        piece_type: Option<PieceType>,
+        piece_type: PieceType,
         piece_color: Option<PieceColor>,
     ) -> &'static str {
         match (piece_type, piece_color) {
-            (Some(PieceType::Queen), Some(PieceColor::Black)) => "♕",
-            (Some(PieceType::Queen), Some(PieceColor::White)) => "♛",
-            (Some(PieceType::King), Some(PieceColor::Black)) => "♔",
-            (Some(PieceType::King), Some(PieceColor::White)) => "♚",
-            (Some(PieceType::Rook), Some(PieceColor::Black)) => "♖",
-            (Some(PieceType::Rook), Some(PieceColor::White)) => "♜",
-            (Some(PieceType::Bishop), Some(PieceColor::Black)) => "♗",
-            (Some(PieceType::Bishop), Some(PieceColor::White)) => "♝",
-            (Some(PieceType::Knight), Some(PieceColor::Black)) => "♘",
-            (Some(PieceType::Knight), Some(PieceColor::White)) => "♞",
-            (Some(PieceType::Pawn), Some(PieceColor::Black)) => "♙",
-            (Some(PieceType::Pawn), Some(PieceColor::White)) => "♟",
+            (PieceType::Queen, Some(PieceColor::Black)) => "♕",
+            (PieceType::Queen, Some(PieceColor::White)) => "♛",
+            (PieceType::King, Some(PieceColor::Black)) => "♔",
+            (PieceType::King, Some(PieceColor::White)) => "♚",
+            (PieceType::Rook, Some(PieceColor::Black)) => "♖",
+            (PieceType::Rook, Some(PieceColor::White)) => "♜",
+            (PieceType::Bishop, Some(PieceColor::Black)) => "♗",
+            (PieceType::Bishop, Some(PieceColor::White)) => "♝",
+            (PieceType::Knight, Some(PieceColor::Black)) => "♘",
+            (PieceType::Knight, Some(PieceColor::White)) => "♞",
+            (PieceType::Pawn, Some(PieceColor::Black)) => "♙",
+            (PieceType::Pawn, Some(PieceColor::White)) => "♟",
             _ => "NONE",
         }
     }
@@ -149,6 +149,15 @@ impl PieceType {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+pub struct PieceMove {
+    pub piece_type: PieceType,
+    pub from_x: i8,
+    pub from_y: i8,
+    pub to_x: i8,
+    pub to_y: i8,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum PieceColor {
     Black,
     White,
@@ -160,7 +169,7 @@ pub trait Movable {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
     ) -> Vec<Vec<i8>>;
 }
 
@@ -169,7 +178,7 @@ pub trait Position {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
         is_king_checked: bool,
     ) -> Vec<Vec<i8>>;
 
@@ -177,6 +186,6 @@ pub trait Position {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
     ) -> Vec<Vec<i8>>;
 }

--- a/src/pieces/queen.rs
+++ b/src/pieces/queen.rs
@@ -1,5 +1,5 @@
 use super::rook::Rook;
-use super::{Movable, PieceColor, PieceType, Position};
+use super::{Movable, PieceColor, PieceMove, PieceType, Position};
 use crate::board::DisplayMode;
 use crate::pieces::bishop::Bishop;
 use crate::utils::{cleaned_positions, impossible_positions_king_checked};
@@ -12,7 +12,7 @@ impl Movable for Queen {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         let mut positions: Vec<Vec<i8>> = vec![];
 
@@ -41,7 +41,7 @@ impl Position for Queen {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         impossible_positions_king_checked(
@@ -56,7 +56,7 @@ impl Position for Queen {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }

--- a/src/pieces/rook.rs
+++ b/src/pieces/rook.rs
@@ -1,4 +1,4 @@
-use super::{Movable, PieceColor, PieceType, Position};
+use super::{Movable, PieceColor, PieceMove, PieceType, Position};
 use crate::board::DisplayMode;
 use crate::utils::{
     cleaned_positions, get_piece_color, impossible_positions_king_checked, is_cell_color_ally,
@@ -12,7 +12,7 @@ impl Movable for Rook {
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
         allow_move_on_ally_positions: bool,
-        _move_history: &[(Option<PieceType>, String)],
+        _move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         // Pawns can only move in one direction depending on their color
         let mut positions: Vec<Vec<i8>> = vec![];
@@ -170,7 +170,7 @@ impl Position for Rook {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
         _is_king_checked: bool,
     ) -> Vec<Vec<i8>> {
         // If the king is not checked we get then normal moves
@@ -188,7 +188,7 @@ impl Position for Rook {
         coordinates: [i8; 2],
         color: PieceColor,
         board: [[Option<(PieceType, PieceColor)>; 8]; 8],
-        move_history: &[(Option<PieceType>, String)],
+        move_history: &[PieceMove],
     ) -> Vec<Vec<i8>> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     board::{Board, DisplayMode},
     constants::UNDEFINED_POSITION,
-    pieces::{PieceColor, PieceType},
+    pieces::{PieceColor, PieceMove, PieceType},
 };
 use ratatui::{
     layout::{Alignment, Rect},
@@ -72,7 +72,7 @@ pub fn is_vec_in_array(array: Vec<Vec<i8>>, element: [i8; 2]) -> bool {
 pub fn get_all_protected_cells(
     board: [[Option<(PieceType, PieceColor)>; 8]; 8],
     player_turn: PieceColor,
-    move_history: &[(Option<PieceType>, String)],
+    move_history: &[PieceMove],
 ) -> Vec<Vec<i8>> {
     let mut check_cells: Vec<Vec<i8>> = vec![];
     for i in 0..8i8 {
@@ -165,25 +165,21 @@ pub fn get_int_from_char(ch: Option<char>) -> i8 {
     }
 }
 
-pub fn get_latest_move(
-    move_history: &[(Option<PieceType>, String)],
-) -> (Option<PieceType>, String) {
+pub fn get_latest_move(move_history: &[PieceMove]) -> Option<PieceMove> {
     if !move_history.is_empty() {
-        return move_history[move_history.len() - 1].clone();
+        return Some(move_history[move_history.len() - 1].clone());
     }
-    (None, "0000".to_string())
+    None
 }
 
 pub fn did_piece_already_move(
-    move_history: &[(Option<PieceType>, String)],
+    move_history: &[PieceMove],
     original_piece: (Option<PieceType>, [i8; 2]),
 ) -> bool {
     for entry in move_history {
-        let position = entry.1.clone();
-        let from_y = get_int_from_char(position.chars().next());
-        let from_x = get_int_from_char(position.chars().nth(1));
-        // Here there is an entry with the same piece type and the same original position, meaning it moved at some point
-        if entry.0 == original_piece.0 && [from_y, from_x] == original_piece.1 {
+        if Some(entry.piece_type) == original_piece.0
+            && [entry.from_y, entry.from_x] == original_piece.1
+        {
             return true;
         }
     }
@@ -210,7 +206,7 @@ pub fn get_king_coordinates(
 pub fn is_getting_checked(
     board: [[Option<(PieceType, PieceColor)>; 8]; 8],
     player_turn: PieceColor,
-    move_history: &[(Option<PieceType>, String)],
+    move_history: &[PieceMove],
 ) -> bool {
     let coordinates = get_king_coordinates(board, player_turn);
 
@@ -229,7 +225,7 @@ pub fn impossible_positions_king_checked(
     positions: Vec<Vec<i8>>,
     board: [[Option<(PieceType, PieceColor)>; 8]; 8],
     color: PieceColor,
-    move_history: &[(Option<PieceType>, String)],
+    move_history: &[PieceMove],
 ) -> Vec<Vec<i8>> {
     let mut cleaned_position: Vec<Vec<i8>> = vec![];
     for position in positions {


### PR DESCRIPTION
# Better History System

## Description
Rewriting the history system to not rely on strings so it will be easier to work with for other issues. Favors a struct instead of many string conversions until the moves actually have to be displayed.

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This takes PR #64 a step further by getting rid of the option type and the string and replacing the tuple with a proper struct

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Ran through all `cargo test`s and played moves on the board to make sure the history still appeared correctly

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
