### PR TITLE
Wrong path for chess-tui config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "crossterm 0.26.1",
  "dirs",
  "ratatui",
+ "toml",
  "uci",
 ]
 
@@ -474,6 +475,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.193"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +614,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ crossterm = "0.26.1"
 dirs = "5.0.1"
 ratatui = "0.26.1"
 uci = "0.1.3"
+toml = "0.5.8"
 
 [features]
 chess-tui = []

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,11 @@
+use toml::Value;
+
 use crate::{board::Board, board::DisplayMode, constants::Pages};
-use std::error;
+use std::{
+    error,
+    fs::{self, File},
+    io::Write,
+};
 
 /// Application result type.
 pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
@@ -84,10 +90,33 @@ impl App {
                     DisplayMode::ASCII => DisplayMode::DEFAULT,
                     DisplayMode::DEFAULT => DisplayMode::ASCII,
                 };
+                self.update_config();
             }
             3 => self.show_help_popup = true,
             4 => self.current_page = Pages::Credit,
             _ => {}
         }
+    }
+
+    pub fn update_config(&self) {
+        let config_path = dirs::home_dir()
+            .unwrap()
+            .join(".config/chess-tui/config.toml");
+        let mut config = match fs::read_to_string(config_path.clone()) {
+            Ok(content) => content
+                .parse::<Value>()
+                .unwrap_or_else(|_| Value::Table(Default::default())),
+            Err(_) => Value::Table(Default::default()),
+        };
+
+        if let Some(table) = config.as_table_mut() {
+            table.insert(
+                "display_mode".to_string(),
+                Value::String(self.board.display_mode.to_string()),
+            );
+        }
+
+        let mut file = File::create(config_path.clone()).unwrap();
+        file.write_all(config.to_string().as_bytes()).unwrap();
     }
 }

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::{
     constants::{BLACK, UNDEFINED_POSITION, WHITE},
     pieces::{PieceColor, PieceMove, PieceType},
@@ -19,6 +21,15 @@ use uci::Engine;
 pub enum DisplayMode {
     DEFAULT,
     ASCII,
+}
+
+impl fmt::Display for DisplayMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DisplayMode::ASCII => write!(f, "ASCII"),
+            DisplayMode::DEFAULT => write!(f, "DEFAULT"),
+        }
+    }
 }
 
 pub struct Board {
@@ -627,9 +638,11 @@ impl Board {
 
     fn is_latest_move_promotion(&self) -> bool {
         if let Some(last_move) = self.move_history.last() {
-            if let Some(piece_type_to) = get_piece_type(self.board, [last_move.to_y, last_move.to_x])
+            if let Some(piece_type_to) =
+                get_piece_type(self.board, [last_move.to_y, last_move.to_x])
             {
-                if let Some(piece_color) = get_piece_color(self.board, [last_move.to_y, last_move.to_x])
+                if let Some(piece_color) =
+                    get_piece_color(self.board, [last_move.to_y, last_move.to_x])
                 {
                     let last_row = if piece_color == PieceColor::White {
                         0

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 extern crate chess_tui;
 
 use chess_tui::app::{App, AppResult};
+use chess_tui::board::DisplayMode;
 use chess_tui::event::{Event, EventHandler};
 use chess_tui::handler::handle_key_events;
 use chess_tui::tui::Tui;
@@ -10,6 +11,8 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use std::fs::{self, File};
 use std::io::{self, Write};
+use std::path::Path;
+use toml::Value;
 
 /// Simple program to greet a person
 #[derive(Parser, Debug)]
@@ -24,26 +27,33 @@ fn main() -> AppResult<()> {
     // Parse the cli arguments
     let args = Args::parse();
 
-    let config_path = dirs::home_dir().unwrap().join(".chess-tui");
+    let folder_path = dirs::home_dir().unwrap().join(".config/chess-tui");
+    let config_path = dirs::home_dir()
+        .unwrap()
+        .join(".config/chess-tui/config.toml");
 
-    if !args.engine_path.is_empty() {
-        if !config_path.exists() {
-            File::create(&config_path)?;
-        }
-
-        let mut file = File::create(&config_path)?;
-        file.write_all(args.engine_path.as_bytes())?;
-    }
+    // Create the configuration file
+    config_create(&args, &folder_path, &config_path)?;
 
     // Create an application.
-    let mut app = App::default();
+    let mut app: App = App::default();
 
     // We store the chess engine path if there is one
     if let Ok(content) = fs::read_to_string(config_path) {
         if content.trim().is_empty() {
-            app.chess_engine_path = None
+            app.chess_engine_path = None;
         } else {
-            app.chess_engine_path = Some(content)
+            let config = content.parse::<toml::Value>().unwrap();
+            if let Some(engine_path) = config.get("engine_path") {
+                app.chess_engine_path = Some(engine_path.as_str().unwrap().to_string());
+            }
+            // Set the display mode based on the configuration file
+            if let Some(display_mode) = config.get("display_mode") {
+                app.board.display_mode = match display_mode.as_str() {
+                    Some("ASCII") => DisplayMode::ASCII,
+                    _ => DisplayMode::DEFAULT,
+                };
+            }
         }
     } else {
         println!("Error reading the file or the file does not exist");
@@ -72,5 +82,48 @@ fn main() -> AppResult<()> {
 
     // Exit the user interface.
     tui.exit()?;
+    Ok(())
+}
+
+fn config_create(args: &Args, folder_path: &Path, config_path: &Path) -> AppResult<()> {
+    std::fs::create_dir_all(folder_path)?;
+
+    if !config_path.exists() {
+        //write to console
+        File::create(config_path)?;
+    }
+
+    // Attempt to read the configuration file and parse it as a TOML Value.
+    // If we encounter any issues (like the file not being readable or not being valid TOML), we start with a new, empty TOML table instead.
+    let mut config = match fs::read_to_string(config_path) {
+        Ok(content) => content
+            .parse::<Value>()
+            .unwrap_or_else(|_| Value::Table(Default::default())),
+        Err(_) => Value::Table(Default::default()),
+    };
+
+    // We update the configuration with the engine_path and display_mode.
+    // If these keys are already in the configuration, we leave them as they are.
+    // If they're not, we add them with default values.
+    if let Some(table) = config.as_table_mut() {
+        // Only update the engine_path in the configuration if it's not empty
+        if !args.engine_path.is_empty() {
+            table.insert(
+                "engine_path".to_string(),
+                Value::String(args.engine_path.clone()),
+            );
+        } else {
+            table
+                .entry("engine_path".to_string())
+                .or_insert(Value::String("".to_string()));
+        }
+        table
+            .entry("display_mode".to_string())
+            .or_insert(Value::String("DEFAULT".to_string()));
+    }
+
+    let mut file = File::create(config_path)?;
+    file.write_all(config.to_string().as_bytes())?;
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,3 +127,40 @@ fn config_create(args: &Args, folder_path: &Path, config_path: &Path) -> AppResu
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use toml::Value;
+
+    #[test]
+    fn test_config_create() {
+        let args = Args {
+            engine_path: "test_engine_path".to_string(),
+        };
+
+        let folder_path = dirs::home_dir().unwrap().join(".test/chess-tui");
+        let config_path = dirs::home_dir()
+            .unwrap()
+            .join(".test/chess-tui/config.toml");
+
+        let result = config_create(&args, &folder_path, &config_path);
+
+        assert!(result.is_ok());
+        assert!(config_path.exists());
+
+        let content = fs::read_to_string(config_path).unwrap();
+        let config: Value = content.parse().unwrap();
+        let table = config.as_table().unwrap();
+
+        assert_eq!(
+            table.get("engine_path").unwrap().as_str().unwrap(),
+            "test_engine_path"
+        );
+        assert_eq!(
+            table.get("display_mode").unwrap().as_str().unwrap(),
+            "DEFAULT"
+        );
+    }
+}


### PR DESCRIPTION
# Title
Wrong path for chess-tui config file

## Description
Create  the config file in ~/.config/chess-tui/config.toml

Creates two parameter in the toml config
- display_mode = ASCII or DEFAULT
- engine_path = <`path_to_engine`>
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Fixes  (issue)
Too simple config file and "_wrong_" location

## How Has This Been Tested?

I created a simple test that creates the folder and test the values 

- [x] Test test_config_create

