### PR TITLE
improving storage of coordinates

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -34,11 +34,8 @@ impl Coord {
         }
     }
     /// optional new: try making a valid [`Coord`], if can't, return [`None`]
-    pub fn opt_new<T: Into<i32>>(row: T, col: T) -> Option<Self> {
-        let row: i32 = row.into();
+    pub fn opt_new<T: TryInto<u8>>(row: T, col: T) -> Option<Self> {
         let row: u8 = row.try_into().ok()?;
-
-        let col: i32 = col.into();
         let col: u8 = col.try_into().ok()?;
 
         let ret = Coord { row, col };

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use ratatui::style::Color;
 
-pub const UNDEFINED_POSITION: i8 = -1;
+pub const UNDEFINED_POSITION: u8 = u8::MAX;
 pub const WHITE: Color = Color::Rgb(160, 160, 160);
 pub const BLACK: Color = Color::Rgb(128, 95, 69);
 

--- a/src/pieces/bishop.rs
+++ b/src/pieces/bishop.rs
@@ -1,52 +1,50 @@
-use super::{Movable, PieceColor, PieceMove, PieceType, Position};
+use super::{Movable, PieceColor, PieceMove, Position};
+use crate::board::{Coord, GameBoard};
 use crate::constants::DisplayMode;
 use crate::utils::{
     cleaned_positions, get_piece_color, impossible_positions_king_checked, is_cell_color_ally,
-    is_piece_opposite_king, is_valid,
+    is_piece_opposite_king,
 };
 pub struct Bishop;
 
 impl Movable for Bishop {
     fn piece_move(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         allow_move_on_ally_positions: bool,
         _move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
-        let mut positions: Vec<Vec<i8>> = vec![];
+    ) -> Vec<Coord> {
+        let mut positions: Vec<Coord> = vec![];
 
-        let y = coordinates[0];
-        let x = coordinates[1];
+        let y = coordinates.row;
+        let x = coordinates.col;
 
         // for diagonal from piece to top left
-        for i in 1..8i8 {
-            let new_x = x - i;
-            let new_y = y - i;
-            let new_coordinates = [new_y, new_x];
-
-            // Invalid coords
-            if !is_valid(new_coordinates) {
+        for i in 1..8u8 {
+            let new_x: i8 = x as i8 - i as i8;
+            let new_y: i8 = y as i8 - i as i8;
+            let Some(new_coordinates) = Coord::opt_new(new_y, new_x) else {
                 break;
-            }
+            };
 
             // Empty cell
-            if get_piece_color(board, new_coordinates).is_none() {
-                positions.push(new_coordinates.to_vec());
+            if get_piece_color(board, &new_coordinates).is_none() {
+                positions.push(new_coordinates);
                 continue;
             }
             // Ally cell
-            if is_cell_color_ally(board, new_coordinates, color) {
+            if is_cell_color_ally(board, &new_coordinates, color) {
                 if !allow_move_on_ally_positions {
                     break;
                 } else {
-                    positions.push(new_coordinates.to_vec());
+                    positions.push(new_coordinates);
                     break;
                 }
             }
 
             // Enemy cell
-            positions.push(new_coordinates.to_vec());
+            positions.push(new_coordinates);
             if !allow_move_on_ally_positions
                 || !is_piece_opposite_king(board[new_y as usize][new_x as usize], color)
             {
@@ -55,34 +53,34 @@ impl Movable for Bishop {
         }
 
         // for diagonal from piece to bottom right
-        for i in 1..8i8 {
+        for i in 1..8u8 {
             let new_x = x + i;
             let new_y = y + i;
 
-            let new_coordinates = [new_y, new_x];
+            let new_coordinates = Coord::new(new_y, new_x);
 
             // Invalid coords
-            if !is_valid(new_coordinates) {
+            if !new_coordinates.is_valid() {
                 break;
             }
 
             // Empty cell
-            if get_piece_color(board, new_coordinates).is_none() {
-                positions.push(new_coordinates.to_vec());
+            if get_piece_color(board, &new_coordinates).is_none() {
+                positions.push(new_coordinates);
                 continue;
             }
             // Ally cell
-            if is_cell_color_ally(board, new_coordinates, color) {
+            if is_cell_color_ally(board, &new_coordinates, color) {
                 if !allow_move_on_ally_positions {
                     break;
                 } else {
-                    positions.push(new_coordinates.to_vec());
+                    positions.push(new_coordinates);
                     break;
                 }
             }
 
             // Enemy cell
-            positions.push(new_coordinates.to_vec());
+            positions.push(new_coordinates);
             if !allow_move_on_ally_positions
                 || !is_piece_opposite_king(board[new_y as usize][new_x as usize], color)
             {
@@ -91,33 +89,35 @@ impl Movable for Bishop {
         }
 
         // for diagonal from piece to bottom left
-        for i in 1..8i8 {
-            let new_x = x - i;
-            let new_y = y + i;
-            let new_coordinates = [new_y, new_x];
+        for i in 1..8u8 {
+            let new_x: i8 = x as i8 - i as i8;
+            let new_y: i8 = y as i8 + i as i8;
+            let Some(new_coordinates) = Coord::opt_new(new_y, new_x) else {
+                break;
+            };
 
             // Invalid coords
-            if !is_valid(new_coordinates) {
+            if !new_coordinates.is_valid() {
                 break;
             }
 
             // Empty cell
-            if get_piece_color(board, new_coordinates).is_none() {
-                positions.push(new_coordinates.to_vec());
+            if get_piece_color(board, &new_coordinates).is_none() {
+                positions.push(new_coordinates);
                 continue;
             }
             // Ally cell
-            if is_cell_color_ally(board, new_coordinates, color) {
+            if is_cell_color_ally(board, &new_coordinates, color) {
                 if !allow_move_on_ally_positions {
                     break;
                 } else {
-                    positions.push(new_coordinates.to_vec());
+                    positions.push(new_coordinates);
                     break;
                 }
             }
 
             // Enemy cell
-            positions.push(new_coordinates.to_vec());
+            positions.push(new_coordinates);
             if !allow_move_on_ally_positions
                 || !is_piece_opposite_king(board[new_y as usize][new_x as usize], color)
             {
@@ -126,51 +126,51 @@ impl Movable for Bishop {
         }
 
         // for diagonal from piece to top right
-        for i in 1..8i8 {
-            let new_x = x + i;
-            let new_y = y - i;
-            let new_coordinates = [new_y, new_x];
-
-            // Invalid coords
-            if !is_valid(new_coordinates) {
+        for i in 1..8u8 {
+            let new_x = x as i8 + i as i8;
+            let new_y = y as i8 - i as i8;
+            let Some(new_coordinates) = Coord::opt_new(new_y, new_x) else {
                 break;
-            }
+            };
 
             // Empty cell
-            if get_piece_color(board, new_coordinates).is_none() {
-                positions.push(new_coordinates.to_vec());
+            if get_piece_color(board, &new_coordinates).is_none() {
+                positions.push(new_coordinates);
                 continue;
             }
             // Ally cell
-            if is_cell_color_ally(board, new_coordinates, color) {
+            if is_cell_color_ally(board, &new_coordinates, color) {
                 if !allow_move_on_ally_positions {
                     break;
                 } else {
-                    positions.push(new_coordinates.to_vec());
+                    positions.push(new_coordinates);
                     break;
                 }
             }
 
             // Enemy cell
-            positions.push(new_coordinates.to_vec());
+            positions.push(new_coordinates);
             if !allow_move_on_ally_positions
-                || !is_piece_opposite_king(board[new_y as usize][new_x as usize], color)
+                || !is_piece_opposite_king(
+                    board[new_coordinates.row as usize][new_coordinates.col as usize],
+                    color,
+                )
             {
                 break;
             }
         }
-        cleaned_positions(positions)
+        cleaned_positions(&positions)
     }
 }
 
 impl Position for Bishop {
     fn authorized_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
         _is_king_checked: bool,
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         // if the king is checked we clean all the position not resolving the check
         impossible_positions_king_checked(
             coordinates,
@@ -181,11 +181,11 @@ impl Position for Bishop {
         )
     }
     fn protected_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }
 }
@@ -210,7 +210,7 @@ impl Bishop {
 #[cfg(test)]
 mod tests {
     use crate::{
-        board::Board,
+        board::{Board, Coord},
         pieces::{bishop::Bishop, PieceColor, PieceType, Position},
         utils::is_getting_checked,
     };
@@ -240,24 +240,29 @@ mod tests {
         board.set_board(custom_board);
 
         let mut right_positions = vec![
-            vec![0, 0],
-            vec![1, 1],
-            vec![2, 2],
-            vec![3, 3],
-            vec![5, 5],
-            vec![6, 6],
-            vec![7, 7],
-            vec![1, 7],
-            vec![2, 6],
-            vec![3, 5],
-            vec![5, 3],
-            vec![6, 2],
-            vec![7, 1],
+            Coord::new(0, 0),
+            Coord::new(1, 1),
+            Coord::new(2, 2),
+            Coord::new(3, 3),
+            Coord::new(5, 5),
+            Coord::new(6, 6),
+            Coord::new(7, 7),
+            Coord::new(1, 7),
+            Coord::new(2, 6),
+            Coord::new(3, 5),
+            Coord::new(5, 3),
+            Coord::new(6, 2),
+            Coord::new(7, 1),
         ];
         right_positions.sort();
 
-        let mut positions =
-            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Bishop::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -297,22 +302,27 @@ mod tests {
         board.set_board(custom_board);
 
         let mut right_positions = vec![
-            vec![0, 0],
-            vec![1, 1],
-            vec![2, 2],
-            vec![3, 3],
-            vec![5, 5],
-            vec![6, 6],
-            vec![7, 7],
-            vec![3, 5],
-            vec![5, 3],
-            vec![6, 2],
-            vec![7, 1],
+            Coord::new(0, 0),
+            Coord::new(1, 1),
+            Coord::new(2, 2),
+            Coord::new(3, 3),
+            Coord::new(5, 5),
+            Coord::new(6, 6),
+            Coord::new(7, 7),
+            Coord::new(3, 5),
+            Coord::new(5, 3),
+            Coord::new(6, 2),
+            Coord::new(7, 1),
         ];
         right_positions.sort();
 
-        let mut positions =
-            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Bishop::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -370,18 +380,23 @@ mod tests {
         board.set_board(custom_board);
 
         let mut right_positions = vec![
-            vec![3, 3],
-            vec![5, 5],
-            vec![3, 5],
-            vec![2, 6],
-            vec![1, 7],
-            vec![5, 3],
-            vec![6, 2],
+            Coord::new(3, 3),
+            Coord::new(5, 5),
+            Coord::new(3, 5),
+            Coord::new(2, 6),
+            Coord::new(1, 7),
+            Coord::new(5, 3),
+            Coord::new(6, 2),
         ];
         right_positions.sort();
 
-        let mut positions =
-            Bishop::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Bishop::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -432,11 +447,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions = vec![vec![4, 4]];
+        let mut right_positions = vec![Coord::new(4, 4)];
         right_positions.sort();
 
         let mut positions = Bishop::authorized_positions(
-            [5, 5],
+            &Coord::new(5, 5),
             PieceColor::Black,
             board.board,
             &[],
@@ -492,11 +507,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions: Vec<Vec<i8>> = vec![];
+        let mut right_positions: Vec<Coord> = vec![];
         right_positions.sort();
 
         let mut positions = Bishop::authorized_positions(
-            [5, 6],
+            &Coord::new(5, 6),
             PieceColor::Black,
             board.board,
             &[],
@@ -552,11 +567,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions: Vec<Vec<i8>> = vec![vec![2, 6], vec![3, 7]];
+        let mut right_positions = vec![Coord::new(2, 6), Coord::new(3, 7)];
         right_positions.sort();
 
         let mut positions = Bishop::authorized_positions(
-            [1, 5],
+            &Coord::new(1, 5),
             PieceColor::Black,
             board.board,
             &[],

--- a/src/pieces/king.rs
+++ b/src/pieces/king.rs
@@ -1,54 +1,55 @@
 use super::{Movable, PieceColor, PieceMove, PieceType, Position};
+use crate::board::{Coord, GameBoard};
 use crate::constants::DisplayMode;
 use crate::utils::{
     cleaned_positions, did_piece_already_move, get_all_protected_cells, get_piece_type,
-    is_cell_color_ally, is_valid, is_vec_in_array,
+    is_cell_color_ally,
 };
 pub struct King;
 
 impl Movable for King {
     fn piece_move(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         allow_move_on_ally_positions: bool,
         _move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
-        let mut positions: Vec<Vec<i8>> = vec![];
-        let y = coordinates[0];
-        let x = coordinates[1];
+    ) -> Vec<Coord> {
+        let mut positions: Vec<Coord> = vec![];
+        let y = coordinates.row;
+        let x = coordinates.col;
 
         // can move on a complete row
         // Generate positions in all eight possible directions
-        for &dy in &[-1, 0, 1] {
-            for &dx in &[-1, 0, 1] {
+        for &dy in &[-1i8, 0, 1] {
+            for &dx in &[-1i8, 0, 1] {
                 // Skip the case where both dx and dy are zero (the current position)
-                let new_x = x + dx;
-                let new_y = y + dy;
+                let new_x = x as i8 + dx;
+                let new_y = y as i8 + dy;
 
-                let new_coordinates = [new_y, new_x];
-                if is_valid(new_coordinates)
-                    && (!is_cell_color_ally(board, [new_y, new_x], color)
+                let new_coordinates = Coord::new(new_y as u8, new_x as u8);
+                if new_coordinates.is_valid()
+                    && (!is_cell_color_ally(board, &new_coordinates, color)
                         || allow_move_on_ally_positions)
                 {
-                    positions.push(vec![y + dy, x + dx]);
+                    positions.push(new_coordinates);
                 }
             }
         }
 
-        cleaned_positions(positions)
+        cleaned_positions(&positions)
     }
 }
 
 impl Position for King {
     fn authorized_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
         is_king_checked: bool,
-    ) -> Vec<Vec<i8>> {
-        let mut positions: Vec<Vec<i8>> = vec![];
+    ) -> Vec<Coord> {
+        let mut positions: Vec<Coord> = vec![];
         let checked_cells = get_all_protected_cells(board, color, move_history);
 
         let rook_big_castle_x = 0;
@@ -57,26 +58,34 @@ impl Position for King {
         let king_line = if color == PieceColor::White { 7 } else { 0 };
 
         // We check the condition for small and big castling
-        if !did_piece_already_move(move_history, (Some(PieceType::King), [king_line, king_x]))
-            && !is_king_checked
+        if !did_piece_already_move(
+            move_history,
+            (Some(PieceType::King), Coord::new(king_line, king_x)),
+        ) && !is_king_checked
         {
             // We check if there is no pieces between tower and king
 
             // Big castle check
             if !did_piece_already_move(
                 move_history,
-                (Some(PieceType::Rook), [king_line, rook_big_castle_x]),
+                (
+                    Some(PieceType::Rook),
+                    Coord::new(king_line, rook_big_castle_x),
+                ),
             ) && King::check_castling_condition(board, color, 0, 3, &checked_cells)
             {
-                positions.push(vec![king_line, 0]);
+                positions.push(Coord::new(king_line, 0));
             }
             // Small castle check
             if !did_piece_already_move(
                 move_history,
-                (Some(PieceType::Rook), [king_line, rook_small_castle_x]),
+                (
+                    Some(PieceType::Rook),
+                    Coord::new(king_line, rook_small_castle_x),
+                ),
             ) && King::check_castling_condition(board, color, 5, 7, &checked_cells)
             {
-                positions.push(vec![king_line, 7]);
+                positions.push(Coord::new(king_line, 7));
             }
         }
 
@@ -84,7 +93,7 @@ impl Position for King {
         let king_cells = King::piece_move(coordinates, color, board, false, move_history);
 
         for king_position in king_cells.clone() {
-            if !is_vec_in_array(checked_cells.clone(), [king_position[0], king_position[1]]) {
+            if !checked_cells.contains(&king_position) {
                 positions.push(king_position);
             }
         }
@@ -94,11 +103,11 @@ impl Position for King {
 
     // This method is used to calculated the cells the king is actually covering and is used when the other king authorized position is called
     fn protected_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }
 }
@@ -121,26 +130,26 @@ impl King {
 
     // Check if nothing is in between the king and a rook and if none of those cells are getting checked
     pub fn check_castling_condition(
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         color: PieceColor,
         start: i8,
         end: i8,
-        checked_cells: &[Vec<i8>],
+        checked_cells: &[Coord],
     ) -> bool {
         let king_line = if color == PieceColor::White { 7 } else { 0 };
 
         let mut valid_for_castling = true;
 
         for i in start..=end {
-            let new_coordinates = [king_line, i];
+            let new_coordinates = Coord::new(king_line, i as u8);
 
-            if is_vec_in_array(checked_cells.to_owned().clone(), new_coordinates) {
+            if checked_cells.contains(&new_coordinates) {
                 valid_for_castling = false;
             }
             if (i == 7 || i == 0)
-                && (get_piece_type(board, new_coordinates) != Some(PieceType::Rook)
-                    || !is_cell_color_ally(board, new_coordinates, color))
-                || (i != 7 && i != 0 && get_piece_type(board, new_coordinates).is_some())
+                && (get_piece_type(board, &new_coordinates) != Some(PieceType::Rook)
+                    || !is_cell_color_ally(board, &new_coordinates, color))
+                || (i != 7 && i != 0 && get_piece_type(board, &new_coordinates).is_some())
             {
                 valid_for_castling = false;
             }
@@ -153,7 +162,7 @@ impl King {
 #[cfg(test)]
 mod tests {
     use crate::{
-        board::Board,
+        board::{Board, Coord},
         pieces::{king::King, PieceColor, PieceMove, PieceType, Position},
         utils::is_getting_checked,
     };
@@ -209,11 +218,16 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![4, 5], vec![5, 4]];
+        let mut right_positions = vec![Coord::new(4, 5), Coord::new(5, 4)];
         right_positions.sort();
 
-        let mut positions =
-            King::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = King::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -270,11 +284,16 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![3, 4]];
+        let mut right_positions = vec![Coord::new(3, 4)];
         right_positions.sort();
 
-        let mut positions =
-            King::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = King::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -331,11 +350,16 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![4, 5]];
+        let mut right_positions = vec![Coord::new(4, 5)];
         right_positions.sort();
 
-        let mut positions =
-            King::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = King::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -392,11 +416,16 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![7, 3], vec![7, 0]];
+        let mut right_positions = vec![Coord::new(7, 3), Coord::new(7, 0)];
         right_positions.sort();
 
-        let mut positions =
-            King::authorized_positions([7, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = King::authorized_positions(
+            &Coord::new(7, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -453,11 +482,16 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![0, 5], vec![0, 7]];
+        let mut right_positions = vec![Coord::new(0, 5), Coord::new(0, 7)];
         right_positions.sort();
 
-        let mut positions =
-            King::authorized_positions([0, 4], PieceColor::Black, board.board, &[], false);
+        let mut positions = King::authorized_positions(
+            &Coord::new(0, 4),
+            PieceColor::Black,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -514,11 +548,16 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![0, 5]];
+        let mut right_positions = vec![Coord::new(0, 5)];
         right_positions.sort();
 
-        let mut positions =
-            King::authorized_positions([0, 4], PieceColor::Black, board.board, &[], false);
+        let mut positions = King::authorized_positions(
+            &Coord::new(0, 4),
+            PieceColor::Black,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -578,11 +617,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions = vec![vec![0, 5]];
+        let mut right_positions = vec![Coord::new(0, 5)];
         right_positions.sort();
 
         let mut positions = King::authorized_positions(
-            [0, 4],
+            &Coord::new(0, 4),
             PieceColor::Black,
             board.board,
             &[],
@@ -644,34 +683,28 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![0, 5]];
+        let mut right_positions = vec![Coord::new(0, 5)];
         right_positions.sort();
 
         let mut positions = King::authorized_positions(
-            [0, 4],
+            &Coord::new(0, 4),
             PieceColor::Black,
             board.board,
             &[
                 (PieceMove {
                     piece_type: PieceType::Rook,
-                    from_y: 0,
-                    from_x: 7,
-                    to_y: 4,
-                    to_x: 7,
+                    from: Coord::new(0, 7),
+                    to: Coord::new(4, 7),
                 }),
                 (PieceMove {
                     piece_type: PieceType::Pawn,
-                    from_y: 6,
-                    from_x: 2,
-                    to_y: 5,
-                    to_x: 2,
+                    from: Coord::new(6, 2),
+                    to: Coord::new(5, 2),
                 }),
                 (PieceMove {
                     piece_type: PieceType::Rook,
-                    from_y: 4,
-                    from_x: 7,
-                    to_y: 0,
-                    to_x: 7,
+                    from: Coord::new(4, 7),
+                    to: Coord::new(0, 7),
                 }),
             ],
             false,

--- a/src/pieces/mod.rs
+++ b/src/pieces/mod.rs
@@ -1,3 +1,5 @@
+use crate::board::{Coord, GameBoard};
+
 use self::{bishop::Bishop, king::King, knight::Knight, pawn::Pawn, queen::Queen, rook::Rook};
 use super::constants::DisplayMode;
 
@@ -20,12 +22,12 @@ pub enum PieceType {
 impl PieceType {
     pub fn authorized_positions(
         self,
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
         is_king_checked: bool,
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         match self {
             PieceType::Pawn => {
                 Pawn::authorized_positions(coordinates, color, board, move_history, is_king_checked)
@@ -61,12 +63,12 @@ impl PieceType {
     }
 
     pub fn protected_positions(
-        selected_coordinates: [i8; 2],
+        selected_coordinates: &Coord,
         piece_type: PieceType,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         match piece_type {
             PieceType::Pawn => {
                 Pawn::protected_positions(selected_coordinates, color, board, move_history)
@@ -151,10 +153,8 @@ impl PieceType {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct PieceMove {
     pub piece_type: PieceType,
-    pub from_x: i8,
-    pub from_y: i8,
-    pub to_x: i8,
-    pub to_y: i8,
+    pub from: Coord,
+    pub to: Coord,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -165,27 +165,27 @@ pub enum PieceColor {
 
 pub trait Movable {
     fn piece_move(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         allow_move_on_ally_positions: bool,
         move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>>;
+    ) -> Vec<Coord>;
 }
 
 pub trait Position {
     fn authorized_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
         is_king_checked: bool,
-    ) -> Vec<Vec<i8>>;
+    ) -> Vec<Coord>;
 
     fn protected_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>>;
+    ) -> Vec<Coord>;
 }

--- a/src/pieces/pawn.rs
+++ b/src/pieces/pawn.rs
@@ -1,86 +1,96 @@
-use super::{Movable, PieceColor, PieceMove, PieceType, Position};
+use super::{Movable, PieceColor, PieceMove, Position};
+use crate::board::{Coord, GameBoard};
 use crate::constants::DisplayMode;
 use crate::utils::{
     cleaned_positions, get_latest_move, get_piece_color, impossible_positions_king_checked,
-    is_cell_color_ally, is_valid,
+    is_cell_color_ally,
 };
 
 pub struct Pawn;
 
 impl Movable for Pawn {
     fn piece_move(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         allow_move_on_ally_positions: bool,
         move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         // Pawns can only move in one direction depending of their color
         // -1 if they are white (go up) +1 if they are black (go down)
-        let direction = if color == PieceColor::White { -1 } else { 1 };
+        let direction: i8 = if color == PieceColor::White { -1 } else { 1 };
 
-        let mut positions: Vec<Vec<i8>> = vec![];
+        let mut positions: Vec<Coord> = vec![];
 
-        let (y, x) = (coordinates[0], coordinates[1]);
+        let (y, x) = (coordinates.row, coordinates.col);
 
         // move one in front
         let new_x_front_one = x;
-        let new_y_front_one = y + direction;
-        let new_coordinates_front_one = [new_y_front_one, new_x_front_one];
+        let new_y_front_one = y as i8 + direction;
+        let new_coordinates_front_one = Coord::new(new_y_front_one as u8, new_x_front_one);
 
-        if is_valid(new_coordinates_front_one)
+        if new_coordinates_front_one.is_valid()
             && !allow_move_on_ally_positions
-            && get_piece_color(board, new_coordinates_front_one).is_none()
+            && get_piece_color(board, &new_coordinates_front_one).is_none()
         {
             // Empty cell
-            positions.push(new_coordinates_front_one.to_vec());
+            positions.push(new_coordinates_front_one);
 
             // move front a second cell
             let new_x_front_two = x;
-            let new_y_front_two = y + direction * 2;
-            let new_coordinates_front_two = [new_y_front_two, new_x_front_two];
+            let new_y_front_two = y as i8 + direction * 2;
+            let new_coordinates_front_two = Coord::new(new_y_front_two as u8, new_x_front_two);
 
-            if is_valid(new_coordinates_front_two)
-                && get_piece_color(board, new_coordinates_front_two).is_none()
+            if new_coordinates_front_two.is_valid()
+                && get_piece_color(board, &new_coordinates_front_two).is_none()
                 && ((color == PieceColor::White && y == 6)
                     || (color == PieceColor::Black && y == 1))
             {
-                positions.push(new_coordinates_front_two.to_vec());
+                positions.push(new_coordinates_front_two);
             }
         }
 
         // check for enemy piece on the right
         let new_x_right = x + 1;
-        let new_y_right = y + direction;
-        let new_coordinates_right = [new_y_right, new_x_right];
+        let new_y_right = y as i8 + direction;
+        let new_coordinates_right =
+            if let Some(new_coord) = Coord::opt_new(new_y_right, new_x_right as i8) {
+                new_coord
+            } else {
+                Coord::undefined()
+            };
 
         // check for enemy piece on the left
-        let new_x_left = x - 1;
-        let new_y_left = y + direction;
-        let new_coordinates_left = [new_y_left, new_x_left];
+        let new_x_left = x as i8 - 1;
+        let new_y_left = y as i8 + direction;
+        let new_coordinates_left = if let Some(new_coord) = Coord::opt_new(new_y_left, new_x_left) {
+            new_coord
+        } else {
+            Coord::undefined()
+        };
 
         // If we allow on ally position we push it anyway
 
         if allow_move_on_ally_positions {
-            if is_valid(new_coordinates_right) {
-                positions.push(new_coordinates_right.to_vec())
+            if new_coordinates_right.is_valid() {
+                positions.push(new_coordinates_right)
             };
-            if is_valid(new_coordinates_left) {
-                positions.push(new_coordinates_left.to_vec())
+            if new_coordinates_left.is_valid() {
+                positions.push(new_coordinates_left)
             };
         } else {
             // else we check if it's an ally piece
-            if is_valid(new_coordinates_right)
-                && get_piece_color(board, new_coordinates_right).is_some()
-                && !is_cell_color_ally(board, new_coordinates_right, color)
+            if new_coordinates_right.is_valid()
+                && get_piece_color(board, &new_coordinates_right).is_some()
+                && !is_cell_color_ally(board, &new_coordinates_right, color)
             {
-                positions.push(new_coordinates_right.to_vec());
+                positions.push(new_coordinates_right);
             }
-            if is_valid(new_coordinates_left)
-                && get_piece_color(board, new_coordinates_left).is_some()
-                && !is_cell_color_ally(board, new_coordinates_left, color)
+            if new_coordinates_left.is_valid()
+                && get_piece_color(board, &new_coordinates_left).is_some()
+                && !is_cell_color_ally(board, &new_coordinates_left, color)
             {
-                positions.push(new_coordinates_left.to_vec());
+                positions.push(new_coordinates_left);
             }
         }
 
@@ -91,38 +101,38 @@ impl Movable for Pawn {
 
             if color == PieceColor::White {
                 valid_y_start = 1;
-                number_of_cells_move = latest_move.to_y - latest_move.from_y;
+                number_of_cells_move = latest_move.to.row as i8 - latest_move.from.row as i8;
             } else {
                 valid_y_start = 6;
-                number_of_cells_move = latest_move.from_y - latest_move.to_y;
+                number_of_cells_move = latest_move.from.row as i8 - latest_move.to.row as i8;
             };
 
             // We check if the latest move was on the right start cell
             // if it moved 2 cells
             // and if the current pawn is next to this pawn latest position
-            if latest_move.from_y == valid_y_start
+            if latest_move.from.row as i8 == valid_y_start
                 && number_of_cells_move == 2
-                && y == latest_move.to_y
-                && (x == latest_move.to_x - 1 || x == latest_move.to_x + 1)
+                && y == latest_move.to.row
+                && (x == latest_move.to.col - 1 || x == latest_move.to.col + 1)
             {
-                let new_y = latest_move.from_y + -direction;
-                let new_x = latest_move.from_x;
-                positions.push([new_y, new_x].to_vec());
+                let new_y = latest_move.from.row as i8 + -direction;
+                let new_x = latest_move.from.col;
+                positions.push(Coord::new(new_y as u8, new_x));
             }
         }
 
-        cleaned_positions(positions)
+        cleaned_positions(&positions)
     }
 }
 
 impl Position for Pawn {
     fn authorized_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
         _is_king_checked: bool,
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         // If the king is not checked we get then normal moves
         // if the king is checked we clean all the position not resolving the check
         impossible_positions_king_checked(
@@ -135,11 +145,11 @@ impl Position for Pawn {
     }
 
     fn protected_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }
 }
@@ -164,7 +174,7 @@ impl Pawn {
 #[cfg(test)]
 mod tests {
     use crate::{
-        board::Board,
+        board::{Board, Coord},
         pieces::{pawn::Pawn, PieceColor, PieceMove, PieceType, Position},
         utils::is_getting_checked,
     };
@@ -193,11 +203,16 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![3, 4]];
+        let mut right_positions = vec![Coord::new(3, 4)];
         right_positions.sort();
 
-        let mut positions =
-            Pawn::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Pawn::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
         assert_eq!(right_positions, positions);
     }
@@ -226,11 +241,16 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![5, 4], vec![4, 4]];
+        let mut right_positions = vec![Coord::new(5, 4), Coord::new(4, 4)];
         right_positions.sort();
 
-        let mut positions =
-            Pawn::authorized_positions([6, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Pawn::authorized_positions(
+            &Coord::new(6, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
         assert_eq!(right_positions, positions);
     }
@@ -268,11 +288,21 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![2, 3], vec![3, 3], vec![2, 4], vec![2, 2]];
+        let mut right_positions = vec![
+            Coord::new(2, 3),
+            Coord::new(3, 3),
+            Coord::new(2, 4),
+            Coord::new(2, 2),
+        ];
         right_positions.sort();
 
-        let mut positions =
-            Pawn::authorized_positions([1, 3], PieceColor::Black, board.board, &[], false);
+        let mut positions = Pawn::authorized_positions(
+            &Coord::new(1, 3),
+            PieceColor::Black,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
         assert_eq!(right_positions, positions);
     }
@@ -310,11 +340,16 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![2, 4], vec![2, 2]];
+        let mut right_positions = vec![Coord::new(2, 4), Coord::new(2, 2)];
         right_positions.sort();
 
-        let mut positions =
-            Pawn::authorized_positions([1, 3], PieceColor::Black, board.board, &[], false);
+        let mut positions = Pawn::authorized_positions(
+            &Coord::new(1, 3),
+            PieceColor::Black,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
         assert_eq!(right_positions, positions);
     }
@@ -343,19 +378,17 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![2, 2], vec![2, 3]];
+        let mut right_positions = vec![Coord::new(2, 2), Coord::new(2, 3)];
         right_positions.sort();
 
         let mut positions = Pawn::authorized_positions(
-            [3, 3],
+            &Coord::new(3, 3),
             PieceColor::White,
             board.board,
             &[(PieceMove {
                 piece_type: PieceType::Pawn,
-                from_y: 1,
-                from_x: 2,
-                to_y: 3,
-                to_x: 2,
+                from: Coord::new(1, 2),
+                to: Coord::new(3, 2),
             })],
             false,
         );
@@ -387,19 +420,17 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![5, 2], vec![5, 3]];
+        let mut right_positions = vec![Coord::new(5, 2), Coord::new(5, 3)];
         right_positions.sort();
 
         let mut positions = Pawn::authorized_positions(
-            [4, 2],
+            &Coord::new(4, 2),
             PieceColor::Black,
             board.board,
             &[(PieceMove {
                 piece_type: PieceType::Pawn,
-                from_y: 6,
-                from_x: 3,
-                to_y: 4,
-                to_x: 3,
+                from: Coord::new(6, 3),
+                to: Coord::new(4, 3),
             })],
             false,
         );
@@ -440,19 +471,17 @@ mod tests {
         let mut board = Board::default();
         board.set_board(custom_board);
 
-        let mut right_positions = vec![vec![2, 1], vec![3, 1]];
+        let mut right_positions = vec![Coord::new(2, 1), Coord::new(3, 1)];
         right_positions.sort();
 
         let mut positions = Pawn::authorized_positions(
-            [1, 1],
+            &Coord::new(1, 1),
             PieceColor::Black,
             board.board,
             &[(PieceMove {
                 piece_type: PieceType::Pawn,
-                from_y: 6,
-                from_x: 3,
-                to_y: 4,
-                to_x: 3,
+                from: Coord::new(6, 3),
+                to: Coord::new(4, 3),
             })],
             false,
         );
@@ -496,11 +525,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions = vec![vec![3, 2]];
+        let mut right_positions = vec![Coord::new(3, 2)];
         right_positions.sort();
 
         let mut positions = Pawn::authorized_positions(
-            [2, 3],
+            &Coord::new(2, 3),
             PieceColor::Black,
             board.board,
             &[],
@@ -547,11 +576,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions: Vec<Vec<i8>> = vec![];
+        let mut right_positions: Vec<Coord> = vec![];
         right_positions.sort();
 
         let mut positions = Pawn::authorized_positions(
-            [2, 4],
+            &Coord::new(2, 4),
             PieceColor::Black,
             board.board,
             &[],
@@ -607,11 +636,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions: Vec<Vec<i8>> = vec![];
+        let mut right_positions: Vec<Coord> = vec![];
         right_positions.sort();
 
         let mut positions = Pawn::authorized_positions(
-            [1, 5],
+            &Coord::new(1, 5),
             PieceColor::Black,
             board.board,
             &[],

--- a/src/pieces/queen.rs
+++ b/src/pieces/queen.rs
@@ -1,5 +1,6 @@
 use super::rook::Rook;
-use super::{Movable, PieceColor, PieceMove, PieceType, Position};
+use super::{Movable, PieceColor, PieceMove, Position};
+use crate::board::{Coord, GameBoard};
 use crate::constants::DisplayMode;
 use crate::pieces::bishop::Bishop;
 use crate::utils::{cleaned_positions, impossible_positions_king_checked};
@@ -8,13 +9,13 @@ pub struct Queen;
 
 impl Movable for Queen {
     fn piece_move(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         allow_move_on_ally_positions: bool,
         move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
-        let mut positions: Vec<Vec<i8>> = vec![];
+    ) -> Vec<Coord> {
+        let mut positions = vec![];
 
         // Queen = bishop concat rook
         positions.extend(Bishop::piece_move(
@@ -32,18 +33,18 @@ impl Movable for Queen {
             move_history,
         ));
 
-        cleaned_positions(positions)
+        cleaned_positions(&positions)
     }
 }
 
 impl Position for Queen {
     fn authorized_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
         _is_king_checked: bool,
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         impossible_positions_king_checked(
             coordinates,
             Self::piece_move(coordinates, color, board, false, move_history),
@@ -53,11 +54,11 @@ impl Position for Queen {
         )
     }
     fn protected_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }
 }
@@ -82,7 +83,7 @@ impl Queen {
 #[cfg(test)]
 mod tests {
     use crate::{
-        board::Board,
+        board::{Board, Coord},
         pieces::{queen::Queen, PieceColor, PieceType, Position},
         utils::is_getting_checked,
     };
@@ -112,38 +113,43 @@ mod tests {
         board.set_board(custom_board);
 
         let mut right_positions = vec![
-            vec![0, 0],
-            vec![0, 4],
-            vec![1, 1],
-            vec![1, 4],
-            vec![1, 7],
-            vec![2, 2],
-            vec![2, 4],
-            vec![2, 6],
-            vec![3, 3],
-            vec![3, 4],
-            vec![3, 5],
-            vec![4, 0],
-            vec![4, 1],
-            vec![4, 2],
-            vec![4, 3],
-            vec![4, 5],
-            vec![4, 6],
-            vec![4, 7],
-            vec![5, 3],
-            vec![5, 4],
-            vec![5, 5],
-            vec![6, 2],
-            vec![6, 4],
-            vec![6, 6],
-            vec![7, 1],
-            vec![7, 4],
-            vec![7, 7],
+            Coord::new(0, 0),
+            Coord::new(0, 4),
+            Coord::new(1, 1),
+            Coord::new(1, 4),
+            Coord::new(1, 7),
+            Coord::new(2, 2),
+            Coord::new(2, 4),
+            Coord::new(2, 6),
+            Coord::new(3, 3),
+            Coord::new(3, 4),
+            Coord::new(3, 5),
+            Coord::new(4, 0),
+            Coord::new(4, 1),
+            Coord::new(4, 2),
+            Coord::new(4, 3),
+            Coord::new(4, 5),
+            Coord::new(4, 6),
+            Coord::new(4, 7),
+            Coord::new(5, 3),
+            Coord::new(5, 4),
+            Coord::new(5, 5),
+            Coord::new(6, 2),
+            Coord::new(6, 4),
+            Coord::new(6, 6),
+            Coord::new(7, 1),
+            Coord::new(7, 4),
+            Coord::new(7, 7),
         ];
         right_positions.sort();
 
-        let mut positions =
-            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Queen::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -183,36 +189,41 @@ mod tests {
         board.set_board(custom_board);
 
         let mut right_positions = vec![
-            vec![0, 0],
-            vec![0, 4],
-            vec![1, 1],
-            vec![1, 4],
-            vec![2, 2],
-            vec![2, 4],
-            vec![3, 3],
-            vec![3, 4],
-            vec![3, 5],
-            vec![4, 0],
-            vec![4, 1],
-            vec![4, 2],
-            vec![4, 3],
-            vec![4, 5],
-            vec![4, 6],
-            vec![4, 7],
-            vec![5, 3],
-            vec![5, 4],
-            vec![5, 5],
-            vec![6, 2],
-            vec![6, 4],
-            vec![6, 6],
-            vec![7, 1],
-            vec![7, 4],
-            vec![7, 7],
+            Coord::new(0, 0),
+            Coord::new(0, 4),
+            Coord::new(1, 1),
+            Coord::new(1, 4),
+            Coord::new(2, 2),
+            Coord::new(2, 4),
+            Coord::new(3, 3),
+            Coord::new(3, 4),
+            Coord::new(3, 5),
+            Coord::new(4, 0),
+            Coord::new(4, 1),
+            Coord::new(4, 2),
+            Coord::new(4, 3),
+            Coord::new(4, 5),
+            Coord::new(4, 6),
+            Coord::new(4, 7),
+            Coord::new(5, 3),
+            Coord::new(5, 4),
+            Coord::new(5, 5),
+            Coord::new(6, 2),
+            Coord::new(6, 4),
+            Coord::new(6, 6),
+            Coord::new(7, 1),
+            Coord::new(7, 4),
+            Coord::new(7, 7),
         ];
         right_positions.sort();
 
-        let mut positions =
-            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Queen::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -270,28 +281,33 @@ mod tests {
         board.set_board(custom_board);
 
         let mut right_positions = vec![
-            vec![1, 7],
-            vec![2, 6],
-            vec![3, 3],
-            vec![3, 5],
-            vec![4, 1],
-            vec![4, 2],
-            vec![4, 3],
-            vec![4, 5],
-            vec![4, 6],
-            vec![4, 7],
-            vec![5, 3],
-            vec![5, 4],
-            vec![5, 5],
-            vec![6, 2],
-            vec![6, 4],
-            vec![7, 4],
+            Coord::new(1, 7),
+            Coord::new(2, 6),
+            Coord::new(3, 3),
+            Coord::new(3, 5),
+            Coord::new(4, 1),
+            Coord::new(4, 2),
+            Coord::new(4, 3),
+            Coord::new(4, 5),
+            Coord::new(4, 6),
+            Coord::new(4, 7),
+            Coord::new(5, 3),
+            Coord::new(5, 4),
+            Coord::new(5, 5),
+            Coord::new(6, 2),
+            Coord::new(6, 4),
+            Coord::new(7, 4),
         ];
 
         right_positions.sort();
 
-        let mut positions =
-            Queen::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Queen::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -341,11 +357,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions = vec![vec![4, 4]];
+        let mut right_positions = vec![Coord::new(4, 4)];
         right_positions.sort();
 
         let mut positions = Queen::authorized_positions(
-            [5, 5],
+            &Coord::new(5, 5),
             PieceColor::Black,
             board.board,
             &[],
@@ -400,11 +416,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions: Vec<Vec<i8>> = vec![];
+        let mut right_positions: Vec<Coord> = vec![];
         right_positions.sort();
 
         let mut positions = Queen::authorized_positions(
-            [5, 6],
+            &Coord::new(5, 6),
             PieceColor::Black,
             board.board,
             &[],
@@ -460,11 +476,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions: Vec<Vec<i8>> = vec![vec![2, 6], vec![3, 7]];
+        let mut right_positions = vec![Coord::new(2, 6), Coord::new(3, 7)];
         right_positions.sort();
 
         let mut positions = Queen::authorized_positions(
-            [1, 5],
+            &Coord::new(1, 5),
             PieceColor::Black,
             board.board,
             &[],

--- a/src/pieces/rook.rs
+++ b/src/pieces/rook.rs
@@ -1,52 +1,53 @@
-use super::{Movable, PieceColor, PieceMove, PieceType, Position};
+use super::{Movable, PieceColor, PieceMove, Position};
+use crate::board::{Coord, GameBoard};
 use crate::constants::DisplayMode;
 use crate::utils::{
     cleaned_positions, get_piece_color, impossible_positions_king_checked, is_cell_color_ally,
-    is_piece_opposite_king, is_valid,
+    is_piece_opposite_king,
 };
 pub struct Rook;
 
 impl Movable for Rook {
     fn piece_move(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         allow_move_on_ally_positions: bool,
         _move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         // Pawns can only move in one direction depending on their color
-        let mut positions: Vec<Vec<i8>> = vec![];
+        let mut positions = vec![];
 
-        let (y, x) = (coordinates[0], coordinates[1]);
+        let (y, x) = (coordinates.row, coordinates.col);
 
         // RIGHT ROW
-        for i in 1..8i8 {
+        for i in 1..8u8 {
             let new_x = x + i;
             let new_y = y;
-            let new_coordinates = [new_y, new_x];
+            let new_coordinates = Coord::new(new_y, new_x);
 
             // Invalid coords
-            if !is_valid(new_coordinates) {
+            if !new_coordinates.is_valid() {
                 break;
             }
 
             // Empty cell
-            if get_piece_color(board, new_coordinates).is_none() {
-                positions.push(new_coordinates.to_vec());
+            if get_piece_color(board, &new_coordinates).is_none() {
+                positions.push(new_coordinates);
                 continue;
             }
             // Ally cell
-            if is_cell_color_ally(board, new_coordinates, color) {
+            if is_cell_color_ally(board, &new_coordinates, color) {
                 if !allow_move_on_ally_positions {
                     break;
                 } else {
-                    positions.push(new_coordinates.to_vec());
+                    positions.push(new_coordinates);
                     break;
                 }
             }
 
             // Enemy cell
-            positions.push(new_coordinates.to_vec());
+            positions.push(new_coordinates);
             if !allow_move_on_ally_positions
                 || !is_piece_opposite_king(board[new_y as usize][new_x as usize], color)
             {
@@ -56,33 +57,30 @@ impl Movable for Rook {
 
         // LEFT ROW
         for i in 1..=8 {
-            let new_x = x - i;
-            let new_y = y;
-            let new_coordinates = [new_y, new_x];
-
-            // Invalid coords
-            if !is_valid(new_coordinates) {
+            let new_x: i8 = x as i8 - i as i8;
+            let new_y: i8 = y as i8;
+            let Some(new_coordinates) = Coord::opt_new(new_y, new_x) else {
                 break;
-            }
+            };
 
             // Empty piece
-            if get_piece_color(board, new_coordinates).is_none() {
-                positions.push(new_coordinates.to_vec());
+            if get_piece_color(board, &new_coordinates).is_none() {
+                positions.push(new_coordinates);
                 continue;
             }
 
             // Ally piece
-            if is_cell_color_ally(board, new_coordinates, color) {
+            if is_cell_color_ally(board, &new_coordinates, color) {
                 if !allow_move_on_ally_positions {
                     break;
                 } else {
-                    positions.push(new_coordinates.to_vec());
+                    positions.push(new_coordinates);
                     break;
                 }
             }
 
             // Enemy cell
-            positions.push(new_coordinates.to_vec());
+            positions.push(new_coordinates);
             if !allow_move_on_ally_positions
                 || !is_piece_opposite_king(board[new_y as usize][new_x as usize], color)
             {
@@ -91,33 +89,33 @@ impl Movable for Rook {
         }
 
         // BOTTOM ROW
-        for i in 1..8i8 {
+        for i in 1..8u8 {
             let new_x = x;
             let new_y = y + i;
-            let new_coordinates = [new_y, new_x];
+            let new_coordinates = Coord::new(new_y, new_x);
 
             // Invalid coords
-            if !is_valid(new_coordinates) {
+            if !new_coordinates.is_valid() {
                 break;
             }
 
             // Empty cell
-            if get_piece_color(board, new_coordinates).is_none() {
-                positions.push(new_coordinates.to_vec());
+            if get_piece_color(board, &new_coordinates).is_none() {
+                positions.push(new_coordinates);
                 continue;
             }
             // Ally cell
-            if is_cell_color_ally(board, new_coordinates, color) {
+            if is_cell_color_ally(board, &new_coordinates, color) {
                 if !allow_move_on_ally_positions {
                     break;
                 } else {
-                    positions.push(new_coordinates.to_vec());
+                    positions.push(new_coordinates);
                     break;
                 }
             }
 
             // Enemy cell
-            positions.push(new_coordinates.to_vec());
+            positions.push(new_coordinates);
 
             if !allow_move_on_ally_positions
                 || !is_piece_opposite_king(board[new_y as usize][new_x as usize], color)
@@ -127,32 +125,29 @@ impl Movable for Rook {
         }
 
         // UP ROW
-        for i in 1..8i8 {
-            let new_x = x;
-            let new_y = y - i;
-            let new_coordinates = [new_y, new_x];
-
-            // Invalid coords
-            if !is_valid(new_coordinates) {
+        for i in 1..8u8 {
+            let new_x = x as i8;
+            let new_y = y as i8 - i as i8;
+            let Some(new_coordinates) = Coord::opt_new(new_y, new_x) else {
                 break;
-            }
+            };
 
             // Empty cell
-            if get_piece_color(board, new_coordinates).is_none() {
-                positions.push(new_coordinates.to_vec());
+            if get_piece_color(board, &new_coordinates).is_none() {
+                positions.push(new_coordinates);
                 continue;
             }
             // Ally cell
-            if is_cell_color_ally(board, new_coordinates, color) {
+            if is_cell_color_ally(board, &new_coordinates, color) {
                 if !allow_move_on_ally_positions {
                     break;
                 } else {
-                    positions.push(new_coordinates.to_vec());
+                    positions.push(new_coordinates);
                     break;
                 }
             }
             // Enemy cell
-            positions.push(new_coordinates.to_vec());
+            positions.push(new_coordinates);
 
             if !allow_move_on_ally_positions
                 || !is_piece_opposite_king(board[new_y as usize][new_x as usize], color)
@@ -161,18 +156,18 @@ impl Movable for Rook {
             }
         }
 
-        cleaned_positions(positions)
+        cleaned_positions(&positions)
     }
 }
 
 impl Position for Rook {
     fn authorized_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
         _is_king_checked: bool,
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         // If the king is not checked we get then normal moves
         // if the king is checked we clean all the position not resolving the check
         impossible_positions_king_checked(
@@ -185,11 +180,11 @@ impl Position for Rook {
     }
 
     fn protected_positions(
-        coordinates: [i8; 2],
+        coordinates: &Coord,
         color: PieceColor,
-        board: [[Option<(PieceType, PieceColor)>; 8]; 8],
+        board: GameBoard,
         move_history: &[PieceMove],
-    ) -> Vec<Vec<i8>> {
+    ) -> Vec<Coord> {
         Self::piece_move(coordinates, color, board, true, move_history)
     }
 }
@@ -214,7 +209,7 @@ impl Rook {
 #[cfg(test)]
 mod tests {
     use crate::{
-        board::Board,
+        board::{Board, Coord},
         pieces::{rook::Rook, PieceColor, PieceType, Position},
         utils::is_getting_checked,
     };
@@ -244,25 +239,30 @@ mod tests {
         board.set_board(custom_board);
 
         let mut right_positions = vec![
-            vec![7, 4],
-            vec![6, 4],
-            vec![5, 4],
-            vec![3, 4],
-            vec![2, 4],
-            vec![1, 4],
-            vec![0, 4],
-            vec![4, 0],
-            vec![4, 1],
-            vec![4, 2],
-            vec![4, 3],
-            vec![4, 5],
-            vec![4, 6],
-            vec![4, 7],
+            Coord::new(7, 4),
+            Coord::new(6, 4),
+            Coord::new(5, 4),
+            Coord::new(3, 4),
+            Coord::new(2, 4),
+            Coord::new(1, 4),
+            Coord::new(0, 4),
+            Coord::new(4, 0),
+            Coord::new(4, 1),
+            Coord::new(4, 2),
+            Coord::new(4, 3),
+            Coord::new(4, 5),
+            Coord::new(4, 6),
+            Coord::new(4, 7),
         ];
         right_positions.sort();
 
-        let mut positions =
-            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Rook::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
         assert_eq!(right_positions, positions);
     }
@@ -301,22 +301,27 @@ mod tests {
         board.set_board(custom_board);
 
         let mut right_positions = vec![
-            vec![7, 4],
-            vec![6, 4],
-            vec![5, 4],
-            vec![3, 4],
-            vec![4, 0],
-            vec![4, 1],
-            vec![4, 2],
-            vec![4, 3],
-            vec![4, 5],
-            vec![4, 6],
-            vec![4, 7],
+            Coord::new(7, 4),
+            Coord::new(6, 4),
+            Coord::new(5, 4),
+            Coord::new(3, 4),
+            Coord::new(4, 0),
+            Coord::new(4, 1),
+            Coord::new(4, 2),
+            Coord::new(4, 3),
+            Coord::new(4, 5),
+            Coord::new(4, 6),
+            Coord::new(4, 7),
         ];
         right_positions.sort();
 
-        let mut positions =
-            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Rook::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
         assert_eq!(right_positions, positions);
     }
@@ -364,19 +369,24 @@ mod tests {
         board.set_board(custom_board);
 
         let mut right_positions = vec![
-            vec![4, 0],
-            vec![4, 1],
-            vec![4, 2],
-            vec![4, 3],
-            vec![4, 5],
-            vec![4, 6],
-            vec![3, 4],
-            vec![5, 4],
+            Coord::new(4, 0),
+            Coord::new(4, 1),
+            Coord::new(4, 2),
+            Coord::new(4, 3),
+            Coord::new(4, 5),
+            Coord::new(4, 6),
+            Coord::new(3, 4),
+            Coord::new(5, 4),
         ];
         right_positions.sort();
 
-        let mut positions =
-            Rook::authorized_positions([4, 4], PieceColor::White, board.board, &[], false);
+        let mut positions = Rook::authorized_positions(
+            &Coord::new(4, 4),
+            PieceColor::White,
+            board.board,
+            &[],
+            false,
+        );
         positions.sort();
 
         assert_eq!(right_positions, positions);
@@ -427,11 +437,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions = vec![vec![4, 2]];
+        let mut right_positions = vec![Coord::new(4, 2)];
         right_positions.sort();
 
         let mut positions = Rook::authorized_positions(
-            [5, 2],
+            &Coord::new(5, 2),
             PieceColor::Black,
             board.board,
             &[],
@@ -487,11 +497,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions: Vec<Vec<i8>> = vec![];
+        let mut right_positions: Vec<Coord> = vec![];
         right_positions.sort();
 
         let mut positions = Rook::authorized_positions(
-            [5, 3],
+            &Coord::new(5, 3),
             PieceColor::Black,
             board.board,
             &[],
@@ -546,11 +556,11 @@ mod tests {
         let is_king_checked =
             is_getting_checked(board.board, board.player_turn, &board.move_history);
 
-        let mut right_positions: Vec<Vec<i8>> = vec![vec![2, 4], vec![3, 4]];
+        let mut right_positions: Vec<Coord> = vec![Coord::new(2, 4), Coord::new(3, 4)];
         right_positions.sort();
 
         let mut positions = Rook::authorized_positions(
-            [1, 4],
+            &Coord::new(1, 4),
             PieceColor::Black,
             board.board,
             &[],


### PR DESCRIPTION
# Title

## Description

IMO the current implementation for coordinations `[i8; 2]` is not straightforward at all, also doesn't utilize Rust's awesome type-safety features.

I made a

```Rust
struct Coord {
    row: u8,
    col: u8,
}
```

for this, which I think fits the purpose.

I've also implemented `std::ops::Index` and `std::ops::IndexMut` for `Board` to be able to index it with `Coord`, just like @joshka suggested. 


## Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] New and existing unit tests pass locally with my changes
