### PR TITLE
Implemented threefold repetition, solving the issue #67

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -775,6 +775,14 @@ impl Board {
         let copied_moves: Vec<PieceMove> =
             self.move_history.iter().copied().collect();
 
+        // A new game has started
+        if copied_moves.len() <= 1 {
+            unsafe {
+                BOARD_HISTORY = Vec::new();
+                ABSTRACT_BOARD = std::sync::LazyLock::new(|| Mutex::new(Board::default()));
+            }
+        }
+
         unsafe {
             let mut abstract_board = ABSTRACT_BOARD.lock().unwrap();
             // Add the new move
@@ -785,7 +793,7 @@ impl Board {
 
             // Index mapping
             let num_positions: usize = BOARD_HISTORY.len();
-            let mut count_equal = vec![0; num_positions];
+            let mut count_equal = vec![1; num_positions];
             for i in 0..(num_positions - 1) {
                 for j in (i + 1)..num_positions {
                     if equal_boards(BOARD_HISTORY[i], BOARD_HISTORY[j]) {


### PR DESCRIPTION
Threefold repetition

## Description

Changes: init_board(), a function that creates an initial chess board (also called in Board for board field), equal_boards(board1, board2) that returns true if the positions are the same.

draw_by_repetition()

Created BOARD_HISTORY and ABSTRACT_BOARD static variables accessed via locking/unlocking in unsafe code sections. BOARD_HISTORY: a list of boards (since no more than 300 moves in a chess game, the memory occupied
by this addition is reasonable) (BOARD_HISTORY[i] = board after move i), ABSTRACT_BOARD(simulating the moves on
a board to get final states). The variables were declared as static to avoid the situation in which the game is simulated every time draw_by_repetition is called (which is not very well for time complexity...). The moves are take as in the
initial design of draw_by_repetition function, but the rev() part is eliminated as the logic changed. Assuming this is called after every move, only the last move will be added at the BOARD_HISTORY and simulated on ABSTRACT_BOARD. The principle is based on index mapping: count how many boards are equal with i-th board (position). If that count is larger than 3, then return unclaimed draw (as in FIDE rule book || no referee => automatic draw).


Fixes #67

## How Has This Been Tested?
Verified if draw is obtained for some games in 2 players mode.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
