### PR TITLE
fix: bot promotion using UCI standard

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -483,10 +483,26 @@ impl Board {
         let to_y = get_int_from_char(converted_move.chars().nth(2));
         let to_x = get_int_from_char(converted_move.chars().nth(3));
 
+        let mut promotion_piece: Option<PieceType> = None;
+        if movement.chars().count() == 5 {
+            promotion_piece = match movement.chars().nth(4) {
+                Some('q') => Some(PieceType::Queen),
+                Some('r') => Some(PieceType::Rook),
+                Some('b') => Some(PieceType::Bishop),
+                Some('n') => Some(PieceType::Knight),
+                _ => None,
+            };
+        }
+
         self.move_piece_on_the_board(
             &Coord::new(from_y as u8, from_x as u8),
             &Coord::new(to_y as u8, to_x as u8),
         );
+
+        if promotion_piece.is_some() {
+            self.board[to_y as usize][to_x as usize] =
+                Some((promotion_piece.unwrap(), self.player_turn));
+        }
         if self.is_bot_starting {
             self.flip_the_board();
         }


### PR DESCRIPTION
# Fix the promotion for the bot

## Description

Bots can now promote their pawns

Fixes #92 

## How Has This Been Tested?

Letting an empty case on each side and putting a pawn in front to test the promotion. Since it's often the best move the chess engine choose it so we can try it out 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
