### PR TITLE
fix: material diff when castling

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -144,9 +144,9 @@ fn init_board() -> GameBoard {
     [
         [
             Some((PieceType::Rook, PieceColor::Black)),
-            None,
-            None,
-            None,
+            Some((PieceType::Knight, PieceColor::Black)),
+            Some((PieceType::Bishop, PieceColor::Black)),
+            Some((PieceType::Queen, PieceColor::Black)),
             Some((PieceType::King, PieceColor::Black)),
             Some((PieceType::Bishop, PieceColor::Black)),
             Some((PieceType::Knight, PieceColor::Black)),
@@ -182,8 +182,8 @@ fn init_board() -> GameBoard {
             Some((PieceType::Bishop, PieceColor::White)),
             Some((PieceType::Queen, PieceColor::White)),
             Some((PieceType::King, PieceColor::White)),
-            None,
-            None,
+            Some((PieceType::Bishop, PieceColor::White)),
+            Some((PieceType::Knight, PieceColor::White)),
             Some((PieceType::Rook, PieceColor::White)),
         ],
     ]

--- a/src/board.rs
+++ b/src/board.rs
@@ -707,15 +707,16 @@ impl Board {
                     && (piece_type_to != Some(PieceType::Rook)
                         && piece_color != Some(self.player_turn))
                 {
-                    match piece_color.unwrap() {
-                        PieceColor::Black => {
+                    match piece_color {
+                        Some(PieceColor::Black) => {
                             self.white_taken_pieces.push(piece);
                             self.white_taken_pieces.sort();
                         }
-                        PieceColor::White => {
+                        Some(PieceColor::White) => {
                             self.black_taken_pieces.push(piece);
                             self.black_taken_pieces.sort();
                         }
+                        _ => {}
                     }
                 }
             }

--- a/src/board.rs
+++ b/src/board.rs
@@ -144,9 +144,9 @@ fn init_board() -> GameBoard {
     [
         [
             Some((PieceType::Rook, PieceColor::Black)),
-            Some((PieceType::Knight, PieceColor::Black)),
-            Some((PieceType::Bishop, PieceColor::Black)),
-            Some((PieceType::Queen, PieceColor::Black)),
+            None,
+            None,
+            None,
             Some((PieceType::King, PieceColor::Black)),
             Some((PieceType::Bishop, PieceColor::Black)),
             Some((PieceType::Knight, PieceColor::Black)),
@@ -182,8 +182,8 @@ fn init_board() -> GameBoard {
             Some((PieceType::Bishop, PieceColor::White)),
             Some((PieceType::Queen, PieceColor::White)),
             Some((PieceType::King, PieceColor::White)),
-            Some((PieceType::Bishop, PieceColor::White)),
-            Some((PieceType::Knight, PieceColor::White)),
+            None,
+            None,
             Some((PieceType::Rook, PieceColor::White)),
         ],
     ]
@@ -702,8 +702,12 @@ impl Board {
             (_, None) => {}
             (_, Some(piece)) => {
                 let piece_color = get_piece_color(self.board, to);
-                if let Some(piece_color) = piece_color {
-                    match piece_color {
+                // We check if there is a piece and we are not doing a castle
+                if piece_color.is_some()
+                    && (piece_type_to != Some(PieceType::Rook)
+                        && piece_color != Some(self.player_turn))
+                {
+                    match piece_color.unwrap() {
                         PieceColor::Black => {
                             self.white_taken_pieces.push(piece);
                             self.white_taken_pieces.sort();


### PR DESCRIPTION
# Fix the material difference feature when doing a castle

## Description

Currently, when doing a castle the `to` position is the one of the Rook, this is not very good since other chess boards don't use that it could be fixed to be the one cell the king will go after castle instead. 

This cause the game logic to be re thinked when adding to the material diff to avoid making the game think we just ate a piece when we just castled 

Fixes #91 

## How Has This Been Tested?

Manually through the board itself

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
