### PR TITLE
fix: en passant make sure we eat the piece

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -673,11 +673,6 @@ impl Board {
         if !from.is_valid() || !to.is_valid() {
             return;
         }
-        let direction_y: i32 = if self.player_turn == PieceColor::White {
-            -1
-        } else {
-            1
-        };
 
         let piece_type_from = get_piece_type(self.board, from);
         let piece_type_to = get_piece_type(self.board, to);
@@ -725,7 +720,7 @@ impl Board {
         // We check for en passant as the latest move
         if self.is_latest_move_en_passant(*from, *to) {
             // we kill the pawn
-            let row_index = to.row as i32 - direction_y;
+            let row_index = to.row as i32 + 1;
 
             self.board[row_index as usize][to.col as usize] = None;
         }

--- a/tests/pieces/pawn.rs
+++ b/tests/pieces/pawn.rs
@@ -297,6 +297,31 @@ mod tests {
         );
         positions.sort();
         assert_eq!(right_positions, positions);
+
+        // Perform the en passant move
+        board.move_piece_on_the_board(&Coord { row: 3, col: 2 }, &Coord { row: 2, col: 3 });
+
+        let board_after_move = [
+            [None, None, None, None, None, None, None, None],
+            [None, None, None, None, None, None, None, None],
+            [
+                None,
+                None,
+                None,
+                Some((PieceType::Pawn, PieceColor::White)),
+                None,
+                None,
+                None,
+                None,
+            ],
+            [None, None, None, None, None, None, None, None],
+            [None, None, None, None, None, None, None, None],
+            [None, None, None, None, None, None, None, None],
+            [None, None, None, None, None, None, None, None],
+            [None, None, None, None, None, None, None, None],
+        ];
+
+        assert_eq!(board_after_move, board.board);
     }
 
     #[test]
@@ -340,6 +365,30 @@ mod tests {
         );
         positions.sort();
         assert_eq!(right_positions, positions);
+
+        board.move_piece_on_the_board(&Coord { row: 3, col: 2 }, &Coord { row: 2, col: 3 });
+
+        let board_after_move = [
+            [None, None, None, None, None, None, None, None],
+            [None, None, None, None, None, None, None, None],
+            [
+                None,
+                None,
+                None,
+                Some((PieceType::Pawn, PieceColor::Black)),
+                None,
+                None,
+                None,
+                None,
+            ],
+            [None, None, None, None, None, None, None, None],
+            [None, None, None, None, None, None, None, None],
+            [None, None, None, None, None, None, None, None],
+            [None, None, None, None, None, None, None, None],
+            [None, None, None, None, None, None, None, None],
+        ];
+
+        assert_eq!(board_after_move, board.board);
     }
 
     #[test]


### PR DESCRIPTION
# Fix en passant

## Description


Fixes #108 

## How Has This Been Tested?

- Adding additional part in the existing en passant tests to move the piece and check the board afterwards
- Reproducing the same position as described in the issue

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
