### PR TITLE
fix: esc key bug when playing bot

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -204,11 +204,6 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                 }
 
                 match app.current_page {
-                    Pages::Bot => {
-                        app.current_page = Pages::Home;
-                        app.menu_cursor = 0;
-                        app.selected_color = None;
-                    }
                     Pages::Credit => {
                         app.current_page = Pages::Home;
                     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -203,11 +203,8 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                     _ => {}
                 }
 
-                match app.current_page {
-                    Pages::Credit => {
-                        app.current_page = Pages::Home;
-                    }
-                    _ => {}
+                if app.current_page == Pages::Credit {
+                    app.current_page = Pages::Home;
                 }
 
                 app.game.ui.unselect_cell();


### PR DESCRIPTION
# Quick bugfix on the bot gameplay

## Description

When playing against a bot if you hit esc you will be send to the homepage, this is not what we want


## How Has This Been Tested?

Manual test

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
