### PR TITLE
[FIX] Corrected moves history display

### DIFF
--- a/src/game_logic/ui.rs
+++ b/src/game_logic/ui.rs
@@ -1,7 +1,7 @@
 use super::{coord::Coord, game::Game};
 use crate::{
     constants::{DisplayMode, BLACK, UNDEFINED_POSITION, WHITE},
-    pieces::{PieceColor, PieceMove, PieceType},
+    pieces::{PieceColor, PieceType},
     ui::{main_ui::render_cell, prompt::Prompt},
     utils::{convert_position_into_notation, get_cell_paragraph, invert_position},
 };
@@ -185,7 +185,8 @@ impl UI {
         for i in (0..game.game_board.move_history.len()).step_by(2) {
             let piece_type_from = game.game_board.move_history[i].piece_type;
 
-            let utf_icon_white = PieceType::piece_to_utf_enum(&piece_type_from, Some(PieceColor::White));
+            let utf_icon_white =
+                PieceType::piece_to_utf_enum(&piece_type_from, Some(PieceColor::White));
             let move_white = convert_position_into_notation(&format!(
                 "{}{}{}{}",
                 game.game_board.move_history[i].from.row,
@@ -206,7 +207,7 @@ impl UI {
                 let (from, to) = if game.bot.is_none() {
                     (
                         invert_position(&black_move.from),
-                        invert_position(&black_move.to)
+                        invert_position(&black_move.to),
                     )
                 } else {
                     (black_move.from, black_move.to)
@@ -214,19 +215,17 @@ impl UI {
 
                 move_black = convert_position_into_notation(&format!(
                     "{}{}{}{}",
-                    from.row,
-                    from.col,
-                    to.row,
-                    to.col
+                    from.row, from.col, to.row, to.col
                 ));
-                utf_icon_black = PieceType::piece_to_utf_enum(&piece_type_to, Some(PieceColor::Black));
+                utf_icon_black =
+                    PieceType::piece_to_utf_enum(&piece_type_to, Some(PieceColor::Black));
             }
 
             lines.push(Line::from(vec![
                 Span::raw(format!("{}.  ", i / 2 + 1)), // line number
                 Span::styled(format!("{utf_icon_white} "), Style::default().fg(WHITE)), // white symbol
                 Span::raw(move_white.to_string()), // white move
-                Span::raw("     "), // separator
+                Span::raw("     "),                // separator
                 Span::styled(format!("{utf_icon_black} "), Style::default().fg(WHITE)), // black symbol
                 Span::raw(move_black.to_string()), // black move
             ]));
@@ -242,7 +241,10 @@ impl UI {
             .split(area);
 
         frame.render_widget(history_block.clone(), right_panel_layout[0]);
-        frame.render_widget(history_paragraph, history_block.inner(right_panel_layout[0]));
+        frame.render_widget(
+            history_paragraph,
+            history_block.inner(right_panel_layout[0]),
+        );
     }
 
     /// Method to render the white material

--- a/src/game_logic/ui.rs
+++ b/src/game_logic/ui.rs
@@ -171,7 +171,7 @@ impl UI {
     }
 
     /// Method to render the right panel history
-    pub fn history_render(&self, area: Rect, frame: &mut Frame, move_history: &[PieceMove]) {
+    pub fn history_render(&self, area: Rect, frame: &mut Frame, game: &Game) {
         // We write the history board on the side
         let history_block = Block::default()
             .title("History")
@@ -182,43 +182,52 @@ impl UI {
 
         let mut lines: Vec<Line> = vec![];
 
-        for i in (0..move_history.len()).step_by(2) {
-            let piece_type_from = move_history[i].piece_type;
+        for i in (0..game.game_board.move_history.len()).step_by(2) {
+            let piece_type_from = game.game_board.move_history[i].piece_type;
 
-            let utf_icon_white =
-                PieceType::piece_to_utf_enum(&piece_type_from, Some(PieceColor::White));
+            let utf_icon_white = PieceType::piece_to_utf_enum(&piece_type_from, Some(PieceColor::White));
             let move_white = convert_position_into_notation(&format!(
                 "{}{}{}{}",
-                move_history[i].from.row,
-                move_history[i].from.col,
-                move_history[i].to.row,
-                move_history[i].to.col
+                game.game_board.move_history[i].from.row,
+                game.game_board.move_history[i].from.col,
+                game.game_board.move_history[i].to.row,
+                game.game_board.move_history[i].to.col
             ));
 
             let mut utf_icon_black = "   ";
             let mut move_black: String = "   ".to_string();
 
             // If there is something for black
-            if i + 1 < move_history.len() {
-                let piece_type_to = move_history[i + 1].piece_type;
+            if i + 1 < game.game_board.move_history.len() {
+                let piece_type_to = game.game_board.move_history[i + 1].piece_type;
+                let black_move = &game.game_board.move_history[i + 1];
+
+                // Invert black moves if not playing against bot
+                let (from, to) = if game.bot.is_none() {
+                    (
+                        invert_position(&black_move.from),
+                        invert_position(&black_move.to)
+                    )
+                } else {
+                    (black_move.from, black_move.to)
+                };
 
                 move_black = convert_position_into_notation(&format!(
                     "{}{}{}{}",
-                    move_history[i + 1].from.row,
-                    move_history[i + 1].from.col,
-                    move_history[i + 1].to.row,
-                    move_history[i + 1].to.col
+                    from.row,
+                    from.col,
+                    to.row,
+                    to.col
                 ));
-                utf_icon_black =
-                    PieceType::piece_to_utf_enum(&piece_type_to, Some(PieceColor::Black));
+                utf_icon_black = PieceType::piece_to_utf_enum(&piece_type_to, Some(PieceColor::Black));
             }
 
             lines.push(Line::from(vec![
                 Span::raw(format!("{}.  ", i / 2 + 1)), // line number
                 Span::styled(format!("{utf_icon_white} "), Style::default().fg(WHITE)), // white symbol
                 Span::raw(move_white.to_string()), // white move
-                Span::raw("     "),                // separator
-                Span::styled(format!("{utf_icon_black} "), Style::default().fg(WHITE)), // white symbol
+                Span::raw("     "), // separator
+                Span::styled(format!("{utf_icon_black} "), Style::default().fg(WHITE)), // black symbol
                 Span::raw(move_black.to_string()), // black move
             ]));
         }
@@ -233,10 +242,7 @@ impl UI {
             .split(area);
 
         frame.render_widget(history_block.clone(), right_panel_layout[0]);
-        frame.render_widget(
-            history_paragraph,
-            history_block.inner(right_panel_layout[0]),
-        );
+        frame.render_widget(history_paragraph, history_block.inner(right_panel_layout[0]));
     }
 
     /// Method to render the white material

--- a/src/ui/main_ui.rs
+++ b/src/ui/main_ui.rs
@@ -251,11 +251,9 @@ pub fn render_game_ui(frame: &mut Frame<'_>, app: &mut App, main_area: Rect) {
     );
 
     // We make the inside of the board
-    app.game.ui.history_render(
-        board_block.inner(right_box_layout[1]),
-        frame,
-        &app.game.game_board.move_history,
-    );
+    app.game
+        .ui
+        .history_render(board_block.inner(right_box_layout[1]), frame, &app.game);
 
     //bottom box for black matetrial
     app.game.ui.white_material_render(


### PR DESCRIPTION
# Fix move history display for player vs player games
## Description
### Before
<img width="1312" alt="Screenshot 2025-02-03 at 10 07 54" src="https://github.com/user-attachments/assets/bcc08df6-4aba-4fbc-bf52-05958a6ed3c8" />


As you can see, the black player’s movements are recorded as if he were the white one, as if the chessboard was inverted.

### After
<img width="1312" alt="Screenshot 2025-02-03 at 10 07 08" src="https://github.com/user-attachments/assets/c70faf98-f76d-480e-a4b1-65514b2125dd" />

Fixes #123 

## How Has This Been Tested?
- [x] Tested move history display in player vs player mode
- [x] Verified correct move notation for black moves
- [x] Confirmed bot games still display moves correctly
- [x] Checked that game state is not affected by display changes

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested the feature in both bot and non-bot game modes
- [x] Existing functionality remains unchanged