### PR TITLE
33. Keyboard shortcuts for moves enhancement

### DIFF
--- a/src/game_logic/ui.rs
+++ b/src/game_logic/ui.rs
@@ -111,24 +111,24 @@ impl UI {
     }
 
     // CURSOR MOVEMENT
-    
+
     pub fn cursor_custom_column(&mut self, to_move_col: u8) {
         if !self.is_cell_selected() {
             self.cursor_coordinates.col = to_move_col;
-        } 
+        }
     }
 
     pub fn cursor_custom_row(&mut self, to_move_row: u8) {
         if !self.is_cell_selected() {
             self.cursor_coordinates.row = to_move_row;
-        } 
+        }
     }
 
     /// Move the cursor up
     pub fn cursor_up(&mut self, authorized_positions: Vec<Coord>) {
         if self.is_cell_selected() {
             self.move_selected_piece_cursor(false, -1, authorized_positions);
-        } else if self.cursor_coordinates.row == 0{
+        } else if self.cursor_coordinates.row == 0 {
             self.cursor_coordinates.row = 7;
         } else {
             self.cursor_coordinates.row -= 1;

--- a/src/game_logic/ui.rs
+++ b/src/game_logic/ui.rs
@@ -111,11 +111,26 @@ impl UI {
     }
 
     // CURSOR MOVEMENT
+    
+    pub fn cursor_custom_column(&mut self, to_move_col: u8) {
+        if !self.is_cell_selected() {
+            self.cursor_coordinates.col = to_move_col;
+        } 
+    }
+
+    pub fn cursor_custom_row(&mut self, to_move_row: u8) {
+        if !self.is_cell_selected() {
+            self.cursor_coordinates.row = to_move_row;
+        } 
+    }
+
     /// Move the cursor up
     pub fn cursor_up(&mut self, authorized_positions: Vec<Coord>) {
         if self.is_cell_selected() {
             self.move_selected_piece_cursor(false, -1, authorized_positions);
-        } else if self.cursor_coordinates.row > 0 {
+        } else if self.cursor_coordinates.row == 0{
+            self.cursor_coordinates.row = 7;
+        } else {
             self.cursor_coordinates.row -= 1;
         }
     }
@@ -124,16 +139,17 @@ impl UI {
     pub fn cursor_down(&mut self, authorized_positions: Vec<Coord>) {
         if self.is_cell_selected() {
             self.move_selected_piece_cursor(false, 1, authorized_positions);
-        } else if self.cursor_coordinates.row < 7 {
-            self.cursor_coordinates.row += 1;
         }
+        self.cursor_coordinates.row = (self.cursor_coordinates.row + 1) % 8;
     }
 
     /// Move the cursor to the left
     pub fn cursor_left(&mut self, authorized_positions: Vec<Coord>) {
         if self.is_cell_selected() {
             self.move_selected_piece_cursor(false, -1, authorized_positions);
-        } else if self.cursor_coordinates.col > 0 {
+        } else if self.cursor_coordinates.col == 0 {
+            self.cursor_coordinates.col = 7;
+        } else {
             self.cursor_coordinates.col -= 1;
         }
     }
@@ -151,9 +167,8 @@ impl UI {
     pub fn cursor_right(&mut self, authorized_positions: Vec<Coord>) {
         if self.is_cell_selected() {
             self.move_selected_piece_cursor(false, 1, authorized_positions);
-        } else if self.cursor_coordinates.col < 7 {
-            self.cursor_coordinates.col += 1;
         }
+        self.cursor_coordinates.col = (self.cursor_coordinates.col + 1) % 8;
     }
 
     /// Move the cursor to the right when we are doing a promotion

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -59,14 +59,34 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                 app.quit();
             }
             // Exit application on `Ctrl-C`
-            KeyCode::Char('c' | 'C') => {
+            KeyCode::Char('C') => {
                 if key_event.modifiers == KeyModifiers::CONTROL {
                     app.quit();
                 }
             }
             // Counter handlers
             // Counter handlers
-            KeyCode::Right | KeyCode::Char('l') => {
+            KeyCode::Char(c) if ('a'..='h').contains(&c) => {
+                let to_move_col: u8 = c as u8 - 97;
+
+                if !(app.game.game_state == GameState::Checkmate)
+                && !(app.game.game_state == GameState::Draw)
+                {
+                    app.game.ui.cursor_custom_column(to_move_col);
+                }
+            }
+
+            KeyCode::Char(r) if ('1'..='8').contains(&r) => {
+                let to_move_row: u8 = r as u8 - 48 - 1;
+
+                if !(app.game.game_state == GameState::Checkmate)
+                && !(app.game.game_state == GameState::Draw)
+                {
+                    app.game.ui.cursor_custom_row(to_move_row);
+                }
+            }
+
+            KeyCode::Right | KeyCode::Char('r') => {
                 if (app.current_page == Pages::Multiplayer
                     && (app.hosting.is_none() || app.selected_color.is_none()))
                     || (app.current_page == Pages::Bot && app.selected_color.is_none())
@@ -85,7 +105,7 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                 }
             }
 
-            KeyCode::Left | KeyCode::Char('h') => {
+            KeyCode::Left | KeyCode::Char('e') => {
                 if (app.current_page == Pages::Multiplayer
                     && (app.hosting.is_none() || app.selected_color.is_none()))
                     || (app.current_page == Pages::Bot && app.selected_color.is_none())
@@ -104,7 +124,7 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                     app.game.ui.cursor_left(authorized_positions);
                 }
             }
-            KeyCode::Up | KeyCode::Char('k') => {
+            KeyCode::Up | KeyCode::Char('w') => {
                 if app.current_page == Pages::Home {
                     app.menu_cursor_up(Pages::variant_count() as u8);
                 } else if !(app.game.game_state == GameState::Checkmate)
@@ -118,20 +138,20 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                     app.game.ui.cursor_up(authorized_positions);
                 }
             }
-            KeyCode::Down | KeyCode::Char('j') => {
+            KeyCode::Down | KeyCode::Char('s') => {
                 if app.current_page == Pages::Home {
                     app.menu_cursor_down(Pages::variant_count() as u8);
                 } else if !(app.game.game_state == GameState::Checkmate)
                     && !(app.game.game_state == GameState::Draw)
                     && !(app.game.game_state == GameState::Promotion)
-                {
-                    let authorized_positions = app.game.game_board.get_authorized_positions(
-                        app.game.player_turn,
-                        app.game.ui.selected_coordinates,
-                    );
+                    {
+                        let authorized_positions = app.game.game_board.get_authorized_positions(
+                            app.game.player_turn,
+                            app.game.ui.selected_coordinates,
+                        );
 
-                    app.game.ui.cursor_down(authorized_positions);
-                }
+                        app.game.ui.cursor_down(authorized_positions);
+                    }
             }
             KeyCode::Char(' ') | KeyCode::Enter => match app.current_page {
                 Pages::Home => {
@@ -168,7 +188,7 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                     app.toggle_help_popup();
                 }
             }
-            KeyCode::Char('r') => {
+            KeyCode::Char('h') => {
                 // We can't restart the game if it's a multiplayer one
                 if app.game.opponent.is_none() {
                     app.restart();

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -70,7 +70,7 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                 let to_move_col: u8 = c as u8 - 97;
 
                 if !(app.game.game_state == GameState::Checkmate)
-                && !(app.game.game_state == GameState::Draw)
+                    && !(app.game.game_state == GameState::Draw)
                 {
                     app.game.ui.cursor_custom_column(to_move_col);
                 }
@@ -80,7 +80,7 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                 let to_move_row: u8 = r as u8 - 48 - 1;
 
                 if !(app.game.game_state == GameState::Checkmate)
-                && !(app.game.game_state == GameState::Draw)
+                    && !(app.game.game_state == GameState::Draw)
                 {
                     app.game.ui.cursor_custom_row(to_move_row);
                 }
@@ -144,14 +144,14 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
                 } else if !(app.game.game_state == GameState::Checkmate)
                     && !(app.game.game_state == GameState::Draw)
                     && !(app.game.game_state == GameState::Promotion)
-                    {
-                        let authorized_positions = app.game.game_board.get_authorized_positions(
-                            app.game.player_turn,
-                            app.game.ui.selected_coordinates,
-                        );
+                {
+                    let authorized_positions = app.game.game_board.get_authorized_positions(
+                        app.game.player_turn,
+                        app.game.ui.selected_coordinates,
+                    );
 
-                        app.game.ui.cursor_down(authorized_positions);
-                    }
+                    app.game.ui.cursor_down(authorized_positions);
+                }
             }
             KeyCode::Char(' ') | KeyCode::Enter => match app.current_page {
                 Pages::Home => {


### PR DESCRIPTION
#  Keyboard shortcuts for moves enhancement

# **_Do not merge in this state_**.
This is not the final version, so i just need a review and some guiding from here.

## Description

Any gameboard cell could be selected now using key-combos (A8 or 8A will work).
Initially, the cursor will be set on the column corresponding to the given letter / on the row corresponding to the given digit, no matter the order of presses.

Currently, i implemented it only for white view.

As we know, we have columns marked from A to H, but the C/c cases are closing the app.
So, cell movements requires lower letters (a to h), and close-app feature will work only with Ctrl+C (uppercase).

Fixes # (33) Keyboard shortcuts for moves enhancement

## How Has This Been Tested?

I tried to select every cell on gameboard (with select/unselected pieces).

- [x] Test A
- [x] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [not yet] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [_] I have added tests that prove my fix is effective or that my feature works
- [not yet] New and existing unit tests pass locally with my changes
- [_] Any dependent changes have been merged and published in downstream modules
