### PR TITLE
Migrate to `ruci`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +94,15 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "bumpalo"
@@ -134,9 +149,10 @@ dependencies = [
  "dirs",
  "log",
  "ratatui",
+ "ruci",
+ "shakmaty",
  "simplelog",
  "toml",
- "uci",
 ]
 
 [[package]]
@@ -273,6 +289,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "dry-mods"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07828d4f27555ab87d9f8d6f4f1ea5fe57f6b1eced8f61b2a3687cd4db2723d"
 
 [[package]]
 name = "either"
@@ -592,6 +614,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruci"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ce14166628ce01f5a94317bb2039b7d4a002064aa5491eb9a0a7266b573a87c"
+dependencies = [
+ "dry-mods",
+ "paste",
+ "shakmaty",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +673,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "shakmaty"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f414cadc4e727893d1a3b0dca62aaef4c1c821dcbd969f0b10a92e12d684d53a"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.6.0",
+ "btoi",
 ]
 
 [[package]]
@@ -809,15 +853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "uci"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1b9eaa4d073139668463f22d8f5151f53600a10909b9902ffe7547b176044a"
-dependencies = [
- "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ repository = "https://github.com/thomas-mauran/chess-tui"
 clap = { version = "4.4.11", features = ["derive"] }
 dirs = "5.0.1"
 ratatui = "0.28.1"
-uci = "0.2.1"
+ruci = { version = "2.1.0", features = ["engine-sync"] }
 toml = "0.5.8"
 log = "0.4.25"
 simplelog = "0.12.2"
 chrono = "0.4.39"
+shakmaty = { version = "0.27.3", default-features = false }
 
 [features]
 chess-tui = []

--- a/src/game_logic/bot.rs
+++ b/src/game_logic/bot.rs
@@ -1,65 +1,66 @@
-use uci::Engine;
-
 use crate::utils::convert_notation_into_position;
+use ruci::{Engine, Go};
+use shakmaty::fen::Fen;
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::io::BufReader;
+use std::process::{Child, ChildStdin, ChildStdout, Command};
+use std::rc::Rc;
+use std::str::FromStr;
 
 #[derive(Clone)]
 pub struct Bot {
-    // the chess engine
-    pub engine: Engine,
+    // Never waited on because we're cloning the process handle instead of creating a new one...
+    process: Rc<RefCell<Child>>,
+    engine: Rc<RefCell<Engine<BufReader<ChildStdout>, ChildStdin>>>,
     /// Used to indicate if a bot move is following
     pub bot_will_move: bool,
     // if the bot is starting, meaning the player is black
     pub is_bot_starting: bool,
 }
 
-// Custom Default implementation
-impl Default for Bot {
-    fn default() -> Self {
-        Bot {
-            engine: Engine::new("path_to_engine").expect("Failed to load engine"), // Specify the default engine path
-            bot_will_move: false,
-            is_bot_starting: false,
-        }
-    }
-}
-
 impl Bot {
     pub fn new(engine_path: &str, is_bot_starting: bool) -> Bot {
-        let engine = Bot::create_engine(engine_path);
+        let mut process = Command::new(engine_path)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let engine = Rc::new(RefCell::new(
+            Engine::from_process(&mut process, false).unwrap(),
+        ));
 
         Self {
+            process: Rc::new(RefCell::new(process)),
             engine,
             bot_will_move: false,
             is_bot_starting,
         }
     }
 
-    /// Allows you so set a
-    pub fn set_engine(&mut self, engine_path: &str) {
-        self.engine = Bot::create_engine(engine_path)
-    }
+    pub fn get_move(&self, fen: &str) -> String {
+        let mut engine = self.engine.borrow_mut();
 
-    pub fn create_engine(engine_path: &str) -> Engine {
-        match Engine::new(engine_path) {
-            Ok(engine) => engine,
-            Err(e) => {
-                panic!(
-                    "Failed to initialize the engine at path: {}. Error: {:?}",
-                    engine_path, e
-                );
-            }
-        }
-    }
-    /* Method to make a move for the bot
-       We use the UCI protocol to communicate with the chess engine
-    */
-    pub fn get_bot_move(&mut self, fen_position: String) -> String {
-        self.engine.set_position(&(fen_position as String)).unwrap();
-        let best_move = self.engine.bestmove();
-        let Ok(movement) = best_move else {
-            panic!("An error has occured")
-        };
+        engine
+            .send(ruci::Position::Fen {
+                fen: Cow::Owned(Fen::from_str(fen).unwrap()),
+                moves: Cow::Borrowed(&[]),
+            })
+            .unwrap();
 
-        convert_notation_into_position(&movement)
+        let best_move = engine
+            .go(
+                &Go {
+                    depth: Some(18),
+                    ..Default::default()
+                },
+                |_| {},
+            )
+            .unwrap()
+            .take_normal()
+            .unwrap();
+
+        convert_notation_into_position(&best_move.r#move.to_string())
     }
 }

--- a/src/game_logic/bot.rs
+++ b/src/game_logic/bot.rs
@@ -10,7 +10,8 @@ use std::str::FromStr;
 
 #[derive(Clone)]
 pub struct Bot {
-    // Never waited on because we're cloning the process handle instead of creating a new one...
+    // TODO, FIXME: Don't reuse the same process... Chess engines are not meant to be used like this
+    #[allow(dead_code)]
     process: Rc<RefCell<Child>>,
     engine: Rc<RefCell<Engine<BufReader<ChildStdout>, ChildStdin>>>,
     /// Used to indicate if a bot move is following

--- a/src/game_logic/game.rs
+++ b/src/game_logic/game.rs
@@ -241,7 +241,7 @@ impl Game {
 
         // Retrieve the bot move from the bot
         let bot_move = if let Some(bot) = self.bot.as_mut() {
-            bot.get_bot_move(fen_position)
+            bot.get_move(&fen_position)
         } else {
             return;
         };


### PR DESCRIPTION
Uses `ruci` instead of `uci`. Fixes #134, #74. Doesn't `wait` on the engine process, because the existing code is **reusing the bot process instead of creating a new one** (so a `Drop` impl that waits on the process waits on all bot instances, not just the one being dropped!). This should be fixed (`Bot` shouldn't be `Clone` and shouldn't be reused), but I don't have the motivation to do so.