### PR TITLE
ci: upload chess-tui binary to the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,22 @@ jobs:
       - run: cargo build --release
         name: Build release binary
 
+      - run: |
+          TAG=${{ github.event.release.tag_name }}
+          PLATFORM=$(cargo -vV | grep '^host:' | awk '{print $2}')
+          TAR_NAME=chess-tui-$TAG-$PLATFORM.tar.gz
+          echo "TAR_NAME=$TAR_NAME" >> $GITHUB_ENV
+        name: Set TAR_NAME from tag and platform
+
+      - run: |
+          cp target/release/chess-tui .
+          tar -czvf $TAR_NAME ./chess-tui
+        name: Create tar file containing the binary
+
       - uses: softprops/action-gh-release@v2
         name: Upload binary to release
         if: github.ref_type == 'tag'
         with:
-          files: target/release/chess-tui
+          files: ${{ env.TAR_NAME }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release Build
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-upload-binary:
+    name: Build and Upload Binary to release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install the Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Upload binary to release
+        uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
+        with:
+          files: target/release/chess-tui
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,19 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        name: Checkout project
 
-      - name: Install the Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
+        name: Install the Rust toolchain
 
-      - name: Build release binary
-        run: cargo build --release
+      - uses: Swatinem/rust-cache@v2
+        name: Use cached dependencies and artifacts
 
-      - name: Upload binary to release
-        uses: softprops/action-gh-release@v2
+      - run: cargo build --release
+        name: Build release binary
+
+      - uses: softprops/action-gh-release@v2
+        name: Upload binary to release
         if: github.ref_type == 'tag'
         with:
           files: target/release/chess-tui


### PR DESCRIPTION
# Upload `chess-tui` binary (in a tar) in the release

## Description

Upload the binary to the release that has been created.

It will be uploaded as a tar.gz file with this format: `chess-tui-$TAG-$PLATFORM.tar.gz`

Fixes #140 

## How Has This Been Tested?

I've tested it in my fork, and it's working fine.
One of my fear is that the `softprops/action-gh-release@v2` action would overwrite the release body, but it just adds to the files so it's fine
