### PR TITLE
feat: blinking selected cell cursor

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -898,6 +898,9 @@ impl App {
 
     /// Handles the tick event of the terminal.
     pub fn tick(&mut self) {
+        // Update cursor blink state (used to flicker the cursor cell when a piece is selected)
+        self.game.ui.update_cursor_blink();
+
         // Handle puzzle logic
         if let Some(mut puzzle_game) = self.puzzle_game.take() {
             puzzle_game.check_elo_update();


### PR DESCRIPTION
# Make the cursor cell blink

## Description

It is hard to detect where a piece will move visually, making the cell blink will make it easier.

Fixes #168 

## How Has This Been Tested?

Manual testing 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
