### PR TITLE
feat: allow engine to have an argument too

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,14 @@ For installation via package managers or other methods, see the [Installation Gu
 
 **Connect a chess engine:**
 ```bash
+# Simple engine path
 chess-tui -e /path/to/engine
+
+# Engine with command-line arguments (e.g., GNU Chess with UCI mode)
+chess-tui -e "/opt/homebrew/bin/gnuchess --uci"
+
+# Stockfish example
+chess-tui -e /opt/homebrew/bin/stockfish
 ```
 See [Bot Configuration](https://thomas-mauran.github.io/chess-tui/docs/Configuration/bot) for details.
 

--- a/src/game_logic/bot.rs
+++ b/src/game_logic/bot.rs
@@ -27,7 +27,21 @@ impl Bot {
     }
 
     pub fn get_move(&self, fen: &str) -> UciMove {
-        let mut process = Command::new(&self.engine_path)
+        // Parse engine_path to support command-line arguments
+        // Split by spaces, treating first part as command and rest as args
+        let parts: Vec<&str> = self.engine_path.split_whitespace().collect();
+        let (command, args) = if parts.is_empty() {
+            (self.engine_path.as_str(), &[] as &[&str])
+        } else {
+            (parts[0], &parts[1..])
+        };
+
+        let mut cmd = Command::new(command);
+        if !args.is_empty() {
+            cmd.args(args);
+        }
+
+        let mut process = cmd
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .spawn()

--- a/src/ui/main_ui.rs
+++ b/src/ui/main_ui.rs
@@ -95,7 +95,9 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
         }
         // Check if engine path exists and is a valid file
         else if let Some(engine_path) = &app.chess_engine_path {
-            let path = Path::new(engine_path);
+            // Extract just the command path (first part before any arguments)
+            let command_path = engine_path.split_whitespace().next().unwrap_or(engine_path);
+            let path = Path::new(command_path);
             if !path.exists() || !path.is_file() {
                 app.error_message = Some(
                     format!(
@@ -108,7 +110,7 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
                         chess-tui -e /opt/homebrew/bin/stockfish\n\
                         or execute the script: ./scripts/install-stockfish.sh\n\
                         to install stockfish automatically and set it as the chess engine path",
-                        engine_path
+                        command_path
                     )
                 );
                 app.current_popup = Some(Popups::Error);

--- a/website/docs/Configuration/bot.md
+++ b/website/docs/Configuration/bot.md
@@ -45,13 +45,18 @@ engine_path = "/path/to/your/engine"
 You can also set the engine path via command line:
 
 ```bash
+# Simple path
 chess-tui -e /path/to/your/engine
+
+# Path with command-line arguments (e.g., GNU Chess)
+chess-tui -e "/opt/homebrew/bin/gnuchess --uci"
 ```
 
 Or with the long form:
 
 ```bash
 chess-tui --engine-path /path/to/your/engine
+chess-tui --engine-path "/opt/homebrew/bin/gnuchess --uci"
 ```
 
 The path will be automatically saved to your configuration file for future use.
@@ -60,6 +65,7 @@ The path will be automatically saved to your configuration file for future use.
 
 Any UCI-compatible chess engine should work. Some popular options include:
 - **Stockfish** - Popular open-source engine (recommended)
+- **GNU Chess** - Classic chess engine (requires `--uci` flag)
 - **Leela Chess Zero** - Neural network engine
 - **Komodo** - Commercial engine
 
@@ -67,12 +73,35 @@ Any UCI-compatible chess engine should work. Some popular options include:
 The engine path must point to a valid UCI-compatible chess engine executable. If not configured correctly, the bot play option will be disabled.
 :::
 
+### Engines Requiring Command-Line Arguments
+
+Some chess engines require command-line arguments to enable UCI mode. For example, GNU Chess requires the `--uci` flag. You can specify these arguments directly in the engine path:
+
+**Command Line:**
+```bash
+chess-tui -e "/opt/homebrew/bin/gnuchess --uci"
+```
+
+**Configuration File:**
+```toml
+engine_path = "/opt/homebrew/bin/gnuchess --uci"
+```
+
+:::tip
+When using quotes in the command line, use double quotes to ensure the entire path and arguments are treated as a single value. In the configuration file, quotes are not needed.
+:::
+
 ### Common Engine Paths
 
-Common Stockfish installation paths:
+**Stockfish:**
 - **macOS (Homebrew)**: `/opt/homebrew/bin/stockfish` or `/usr/local/bin/stockfish`
 - **Linux (apt)**: `/usr/bin/stockfish`
 - **Linux (dnf/pacman)**: `/usr/bin/stockfish`
+
+**GNU Chess (requires `--uci` flag):**
+- **macOS (Homebrew)**: `/opt/homebrew/bin/gnuchess --uci` or `/usr/local/bin/gnuchess --uci`
+- **Linux (apt)**: `/usr/bin/gnuchess --uci`
+- **Linux (dnf/pacman)**: `/usr/bin/gnuchess --uci`
 
 ## Bot Configuration
 
@@ -149,3 +178,23 @@ If you see an error that the engine path is invalid:
 2. **Verify permissions**: Ensure the file is executable (`chmod +x /path/to/engine`)
 3. **Test manually**: Try running the engine from the command line to verify it works
 4. **Use the install script**: If using Stockfish, try the automatic installation script
+
+### Engine Not Responding
+
+If the engine path is valid but the engine doesn't respond during gameplay:
+
+1. **Check UCI compatibility**: Ensure your engine supports the UCI protocol
+2. **Add required flags**: Some engines (like GNU Chess) require command-line arguments to enable UCI mode:
+   ```bash
+   chess-tui -e "/opt/homebrew/bin/gnuchess --uci"
+   ```
+3. **Test UCI mode**: Test the engine manually in UCI mode:
+   ```bash
+   echo "uci" | /path/to/engine --uci
+   ```
+   You should see `uciok` in the response
+4. **Check logs**: Enable logging to see detailed error messages:
+   ```bash
+   chess-tui -e /path/to/engine
+   # Then check logs in CONFIG_DIR/chess-tui/logs/
+   ```

--- a/website/docs/Configuration/intro.md
+++ b/website/docs/Configuration/intro.md
@@ -21,11 +21,18 @@ Some configuration options can also be set directly from the command line:
 # Set chess engine path
 chess-tui -e /path/to/engine
 
+# Set engine path with command-line arguments (e.g., GNU Chess)
+chess-tui -e "/opt/homebrew/bin/gnuchess --uci"
+
 # Set bot thinking depth
 chess-tui --depth 15
 
 # Combine both options
 chess-tui -e /path/to/engine --depth 15
+chess-tui -e "/opt/homebrew/bin/gnuchess --uci" --depth 15
+
+# Stockfish simple example
+chess-tui -e /opt/homebrew/opt/stockfish
 ```
 
 Command line options take precedence over configuration file values.
@@ -41,7 +48,9 @@ The configuration file is automatically created when you first run chess-tui. Yo
 display_mode = "DEFAULT"
 
 # Chess engine path (optional)
+# Can include command-line arguments for engines that require them
 engine_path = "/path/to/your/engine"
+# Example with GNU Chess: engine_path = "/opt/homebrew/bin/gnuchess --uci"
 
 # Logging level: "OFF", "ERROR", "WARN", "INFO", "DEBUG", or "TRACE"
 log_level = "OFF"


### PR DESCRIPTION
# Allow user to pass an argument as well as the chess engine path

## Description

Some chess engine like gnuchess requires an argument to be runned in UCI mode.
[Documentation](https://www.gnu.org/software/chess/manual/html_node/UCI-chess-engine.html)

To fix that we wanna be able to pass on top of the path to the engine and argument as

```bash
chess-tui -e "/opt/homebrew/bin/gnuchess --uci"
```

Fixes #74 

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
