### PR TITLE
fix: parse args before mousetrack

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,13 +33,14 @@ struct Args {
 }
 
 fn main() -> AppResult<()> {
-    // Used to enable mouse capture
+    // Parse the cli arguments first (this will handle --version and exit early if needed)
+    let args = Args::parse();
+
+    // Used to enable mouse capture (only after we know we're running the TUI)
     ratatui::crossterm::execute!(
         std::io::stdout(),
         ratatui::crossterm::event::EnableMouseCapture
     )?;
-    // Parse the cli arguments
-    let args = Args::parse();
 
     let config_dir = config_dir()?;
     let folder_path = config_dir.join("chess-tui");


### PR DESCRIPTION
# parse args before enabling mouse tracking

## Description

right now when we do --version or any miss spelled commands we dont quit the mouse capture making the terminal unusable

Fixes #176 

## How Has This Been Tested?

manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
