### PR TITLE
Refactor/clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,19 @@ codegen-units = 1
 opt-level = "z"
 strip = true
 
+[lints.clippy]
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+
+style = "warn"
+complexity = "warn"
+perf = "warn"
+
+unwrap_used = "warn"
+expect_used = "warn"
+todo = "warn"
+dbg_macro = "warn"
+
 [package.metadata.deb]
 # Configuration for cargo-deb (alternative packaging method)
 # Install with: cargo install cargo-deb

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -39,6 +39,11 @@ impl fmt::Display for DisplayMode {
     }
 }
 
+/// Returns the user's config directory path.
+///
+/// # Errors
+///
+/// Returns an error if the config directory cannot be determined.
 pub fn config_dir() -> Result<PathBuf, &'static str> {
     match dirs::config_dir() {
         Some(dir) => Ok(dir),
@@ -58,6 +63,7 @@ pub enum Pages {
     Credit,
 }
 impl Pages {
+    #[must_use]
     pub fn variant_count() -> usize {
         7
     }

--- a/src/game_logic/game.rs
+++ b/src/game_logic/game.rs
@@ -461,9 +461,7 @@ impl GameLogic {
             {
                 // Store the move without promotion piece so popup will appear
                 // from() returns None only for drops (non-Normal moves), but we know this is Normal
-                let from_square = executed_move
-                    .from()
-                    .unwrap_or_else(|| executed_move.to());
+                let from_square = executed_move.from().unwrap_or_else(|| executed_move.to());
                 shakmaty::Move::Normal {
                     role: Role::Pawn,
                     from: from_square,

--- a/src/game_logic/game.rs
+++ b/src/game_logic/game.rs
@@ -460,9 +460,13 @@ impl GameLogic {
                 && executed_move.promotion().is_some()
             {
                 // Store the move without promotion piece so popup will appear
+                // from() returns None only for drops (non-Normal moves), but we know this is Normal
+                let from_square = executed_move
+                    .from()
+                    .unwrap_or_else(|| executed_move.to());
                 shakmaty::Move::Normal {
                     role: Role::Pawn,
-                    from: executed_move.from().unwrap(),
+                    from: from_square,
                     capture: executed_move.capture(),
                     to: executed_move.to(),
                     promotion: None,

--- a/src/game_logic/game_board.rs
+++ b/src/game_logic/game_board.rs
@@ -92,15 +92,21 @@ impl GameBoard {
 
     /// Gets a read-only reference to the last position in the history.
     /// If navigating history, returns the position at history_position_index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the position history is empty. This should never happen
+    /// as the game always starts with an initial position.
     pub fn position_ref(&self) -> &Chess {
         if let Some(index) = self.history_position_index {
-            if index < self.position_history.len() {
-                &self.position_history[index]
-            } else {
-                self.position_history.last().unwrap()
-            }
+            self.position_history
+                .get(index)
+                .or_else(|| self.position_history.last())
+                .unwrap_or_else(|| panic!("Position history is empty"))
         } else {
-            self.position_history.last().unwrap()
+            self.position_history
+                .last()
+                .unwrap_or_else(|| panic!("Position history is empty"))
         }
     }
 

--- a/src/game_logic/ui.rs
+++ b/src/game_logic/ui.rs
@@ -157,7 +157,9 @@ impl UI {
             authorized_positions.sort();
 
             // Safe: selected_piece_cursor is always non-negative after the above logic
-            if let Some(position) = authorized_positions.get(self.selected_piece_cursor.unsigned_abs() as usize) {
+            if let Some(position) =
+                authorized_positions.get(self.selected_piece_cursor.unsigned_abs() as usize)
+            {
                 self.cursor_coordinates = *position;
             }
         }
@@ -664,9 +666,9 @@ impl UI {
             board.flip_horizontal();
         }
 
-        let actual_square = self.selected_square.map(|s| {
-            flip_square_if_needed(s, logic.game_board.is_flipped)
-        });
+        let actual_square = self
+            .selected_square
+            .map(|s| flip_square_if_needed(s, logic.game_board.is_flipped));
 
         self.render_board_grid(area, frame, logic, actual_square);
     }
@@ -823,7 +825,8 @@ impl UI {
                 DisplayMode::CUSTOM => {
                     // Use selection color for selected square, last move color for last move
                     if i == get_coord_from_square(actual_square, logic.game_board.is_flipped).row
-                        && j == get_coord_from_square(actual_square, logic.game_board.is_flipped).col
+                        && j == get_coord_from_square(actual_square, logic.game_board.is_flipped)
+                            .col
                     {
                         self.skin.selection_color
                     } else {

--- a/src/game_logic/ui.rs
+++ b/src/game_logic/ui.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use super::{
     coord::Coord,
     game::{Game, GameLogic},
@@ -17,6 +19,23 @@ use ratatui::{
     Frame,
 };
 use shakmaty::{Position, Role, Square};
+
+/// Context for rendering a single cell of the board
+struct CellRenderContext<'a> {
+    logic: &'a GameLogic,
+    i: u8,
+    j: u8,
+    square: Rect,
+    actual_square: Option<Square>,
+    last_move_from: Option<Square>,
+    last_move_to: Option<Square>,
+    authorized_positions: &'a [Coord],
+}
+
+// Constants moved to top of file
+const BLINK_INTERVAL_TICKS: u8 = 2;
+const BIG_MODE_WIDTH: usize = 21; // 5 + 8 + 8 (with numbers, 2 moves on one line)
+const MEDIUM_MODE_WIDTH: usize = 16; // 8 + 8 (no numbers, 2 moves on one line)
 
 #[derive(Clone)]
 pub struct UI {
@@ -92,9 +111,6 @@ impl UI {
     /// When a piece is selected, the cursor cell will toggle visibility every few ticks.
     pub fn update_cursor_blink(&mut self) {
         if self.is_cell_selected() {
-            // Number of ticks between visibility toggles (higher = slower blink)
-            const BLINK_INTERVAL_TICKS: u8 = 2;
-
             self.cursor_blink_counter = self.cursor_blink_counter.wrapping_add(1);
             if self.cursor_blink_counter >= BLINK_INTERVAL_TICKS {
                 self.cursor_blink_visible = !self.cursor_blink_visible;
@@ -108,6 +124,7 @@ impl UI {
     }
 
     /// Check if a cell has been selected
+    #[must_use]
     pub fn is_cell_selected(&self) -> bool {
         self.selected_square.is_some()
     }
@@ -124,13 +141,14 @@ impl UI {
         if authorized_positions.is_empty() {
             self.cursor_coordinates = Coord::undefined();
         } else {
+            // Safe conversion: authorized_positions.len() is bounded by 64 (max chess moves)
+            let len = authorized_positions.len().min(127) as i8;
             self.selected_piece_cursor = if self.selected_piece_cursor == 0 && first_time_moving {
                 0
             } else {
-                let new_cursor =
-                    (self.selected_piece_cursor + direction) % authorized_positions.len() as i8;
+                let new_cursor = (self.selected_piece_cursor + direction) % len;
                 if new_cursor == -1 {
-                    authorized_positions.len() as i8 - 1
+                    len - 1
                 } else {
                     new_cursor
                 }
@@ -138,7 +156,8 @@ impl UI {
 
             authorized_positions.sort();
 
-            if let Some(position) = authorized_positions.get(self.selected_piece_cursor as usize) {
+            // Safe: selected_piece_cursor is always non-negative after the above logic
+            if let Some(position) = authorized_positions.get(self.selected_piece_cursor.unsigned_abs() as usize) {
                 self.cursor_coordinates = *position;
             }
         }
@@ -342,13 +361,6 @@ impl UI {
         let inner_area = history_block.inner(right_panel_layout[0]);
         let available_width = inner_area.width as usize;
 
-        // Calculate widths needed for different formats
-        // Big mode: line number (5 chars: "  1. ") + white move (8) + black move (8) = 21 chars
-        // Medium mode: white move (8) + black move (8) = 16 chars (no numbers)
-        // Small mode: one move per line, 8 chars per move (no numbers)
-        const BIG_MODE_WIDTH: usize = 21; // 5 + 8 + 8 (with numbers, 2 moves on one line)
-        const MEDIUM_MODE_WIDTH: usize = 16; // 8 + 8 (no numbers, 2 moves on one line)
-
         let use_big_mode = available_width >= BIG_MODE_WIDTH;
         let use_medium_mode = !use_big_mode && available_width >= MEDIUM_MODE_WIDTH;
 
@@ -374,10 +386,10 @@ impl UI {
             if use_big_mode {
                 // Format white move: icon + space + move notation (fixed total width of 8 chars)
                 let white_move_formatted =
-                    format!("{:<8}", format!("{utf_icon_white} {}", move_white));
+                    format!("{:<8}", format!("{utf_icon_white} {move_white}"));
                 // Format black move: icon + space + move notation (fixed total width of 8 chars)
                 let black_move_formatted =
-                    format!("{:<8}", format!("{utf_icon_black} {}", move_black));
+                    format!("{:<8}", format!("{utf_icon_black} {move_black}"));
 
                 // Big mode: "  1. ♙ e4    ♟ d5   " (centered, with numbers, 2 moves on one line)
                 lines.push(Line::from(vec![
@@ -388,10 +400,10 @@ impl UI {
             } else if use_medium_mode {
                 // Format white move: icon + space + move notation (fixed total width of 8 chars)
                 let white_move_formatted =
-                    format!("{:<8}", format!("{utf_icon_white} {}", move_white));
+                    format!("{:<8}", format!("{utf_icon_white} {move_white}"));
                 // Format black move: icon + space + move notation (fixed total width of 8 chars)
                 let black_move_formatted =
-                    format!("{:<8}", format!("{utf_icon_black} {}", move_black));
+                    format!("{:<8}", format!("{utf_icon_black} {move_black}"));
 
                 // Medium mode: "♙ e4    ♟ d5   " (centered, no numbers, 2 moves on one line)
                 lines.push(Line::from(vec![
@@ -402,12 +414,12 @@ impl UI {
                 // Small mode: one move per line, no numbers
                 // "♙ e4"
                 // "♟ d5"
-                let white_move_text = format!("{utf_icon_white} {}", move_white);
+                let white_move_text = format!("{utf_icon_white} {move_white}");
                 lines.push(Line::from(vec![
                     Span::styled(white_move_text, Style::default().fg(WHITE)), // white move
                 ]));
                 if !move_black.trim().is_empty() {
-                    let black_move_text = format!("{utf_icon_black} {}", move_black);
+                    let black_move_text = format!("{utf_icon_black} {move_black}");
                     lines.push(Line::from(vec![
                         Span::styled(black_move_text, Style::default().fg(WHITE)), // black move
                     ]));
@@ -441,8 +453,7 @@ impl UI {
 
         for piece in white_taken_pieces {
             let utf_icon_white = role_to_utf_enum(piece, Some(shakmaty::Color::Black));
-
-            pieces.push_str(&format!("{utf_icon_white} "));
+            let _ = write!(pieces, "{utf_icon_white} ");
         }
         let white_material_paragraph = Paragraph::new(pieces)
             .alignment(Alignment::Center)
@@ -486,8 +497,7 @@ impl UI {
 
         for piece in white_taken_pieces {
             let utf_icon_white = role_to_utf_enum(piece, Some(shakmaty::Color::Black));
-
-            pieces.push_str(&format!("{utf_icon_white} "));
+            let _ = write!(pieces, "{utf_icon_white} ");
         }
         let white_material_paragraph = Paragraph::new(pieces)
             .alignment(Alignment::Center)
@@ -534,8 +544,7 @@ impl UI {
 
         for piece in black_taken_pieces {
             let utf_icon_black = role_to_utf_enum(piece, Some(shakmaty::Color::White));
-
-            pieces.push_str(&format!("{utf_icon_black} "));
+            let _ = write!(pieces, "{utf_icon_black} ");
         }
 
         let black_material_paragraph = Paragraph::new(pieces)
@@ -556,15 +565,18 @@ impl UI {
         );
     }
 
-    /// Method to render the board
-    fn get_last_move_squares(&self, logic: &GameLogic) -> (Option<Square>, Option<Square>) {
+    /// Get the last move squares for rendering
+    fn get_last_move_squares(logic: &GameLogic) -> (Option<Square>, Option<Square>) {
         if logic.game_board.move_history.is_empty() {
             return (None, None);
         }
 
-        let last_move = logic.game_board.move_history.last();
-        let last_move_from = last_move.map(|m| m.from()).unwrap();
-        let last_move_to = last_move.map(|m| m.to());
+        let Some(last_move) = logic.game_board.move_history.last() else {
+            return (None, None);
+        };
+
+        let last_move_from = last_move.from();
+        let last_move_to = Some(last_move.to());
 
         // Check if this is multiplayer mode first (TCP or Lichess)
         // In multiplayer modes, always show the last move regardless of who made it
@@ -591,10 +603,9 @@ impl UI {
                 // If the last move was made by the opponent, show it
                 if last_move_color == opponent.color {
                     return (last_move_from, last_move_to);
-                } else {
-                    // Last move was made by the player, don't show it
-                    return (None, None);
                 }
+                // Last move was made by the player, don't show it
+                return (None, None);
             }
         }
 
@@ -607,40 +618,45 @@ impl UI {
         logic: &GameLogic,
         actual_square: Option<Square>,
     ) -> Vec<Coord> {
-        if !self.is_cell_selected() || actual_square.is_none() {
+        let Some(square) = actual_square else {
+            return vec![];
+        };
+
+        if !self.is_cell_selected() {
             return vec![];
         }
 
-        let selected_piece_color = logic
-            .game_board
-            .get_piece_color_at_square(&actual_square.unwrap());
+        let selected_piece_color = logic.game_board.get_piece_color_at_square(&square);
 
         if let Some(color) = selected_piece_color {
             if color == logic.player_turn {
                 let mut authorized_positions: Vec<Coord> = logic
                     .game_board
-                    .get_authorized_positions(logic.player_turn, &actual_square.unwrap())
+                    .get_authorized_positions(logic.player_turn, &square)
                     .iter()
                     .map(|s| Coord::from_square(*s))
                     .collect();
 
                 if logic.game_board.is_flipped {
                     authorized_positions =
-                        authorized_positions.iter().map(|s| s.reverse()).collect();
+                        authorized_positions.iter().map(Coord::reverse).collect();
                 }
                 return authorized_positions;
             }
         }
         vec![]
     }
+
+    /// Render the chess board
+    ///
+    /// # Panics
+    ///
+    /// Panics if position_history is empty (should never happen in normal gameplay)
     pub fn board_render(&mut self, area: Rect, frame: &mut Frame<'_>, logic: &GameLogic) {
-        let mut board = logic
-            .game_board
-            .position_history
-            .last()
-            .unwrap()
-            .board()
-            .clone();
+        let Some(last_position) = logic.game_board.position_history.last() else {
+            return;
+        };
+        let mut board = last_position.board().clone();
 
         // if the board is flipped, we need to flip the board
         if logic.game_board.is_flipped {
@@ -648,14 +664,21 @@ impl UI {
             board.flip_horizontal();
         }
 
-        let mut actual_square = self.selected_square;
-        if self.selected_square.is_some() {
-            actual_square = Some(flip_square_if_needed(
-                self.selected_square.unwrap(),
-                logic.game_board.is_flipped,
-            ));
-        }
+        let actual_square = self.selected_square.map(|s| {
+            flip_square_if_needed(s, logic.game_board.is_flipped)
+        });
 
+        self.render_board_grid(area, frame, logic, actual_square);
+    }
+
+    /// Render the board grid (helper to reduce function size)
+    fn render_board_grid(
+        &mut self,
+        area: Rect,
+        frame: &mut Frame<'_>,
+        logic: &GameLogic,
+        actual_square: Option<Square>,
+    ) {
         let width = area.width / 8;
         let height = area.height / 8;
         let border_height = area.height / 2 - (4 * height);
@@ -687,6 +710,9 @@ impl UI {
             )
             .split(area);
 
+        let (last_move_from, last_move_to) = Self::get_last_move_squares(logic);
+        let authorized_positions = self.get_authorized_positions_for_render(logic, actual_square);
+
         // For each line we set 8 layout
         for i in 0..8u8 {
             let lines = Layout::default()
@@ -707,115 +733,131 @@ impl UI {
                     .as_ref(),
                 )
                 .split(columns[i as usize + 1]);
+
             for j in 0..8u8 {
-                // Color of the cell to draw the board
-                let cell_color: Color = if (i + j) % 2 == 0 {
-                    match self.display_mode {
-                        DisplayMode::CUSTOM => self.skin.board_white_color,
-                        _ => WHITE,
-                    }
-                } else {
-                    match self.display_mode {
-                        DisplayMode::CUSTOM => self.skin.board_black_color,
-                        _ => BLACK,
-                    }
-                };
-
-                let (last_move_from, last_move_to) = self.get_last_move_squares(logic);
-
-                let authorized_positions =
-                    self.get_authorized_positions_for_render(logic, actual_square);
-
-                let is_cell_in_positions = |positions: &Vec<Coord>, i: u8, j: u8| {
-                    positions.iter().any(|&coord| coord == Coord::new(i, j))
-                };
-
                 let square = lines[j as usize + 1];
-                // Here we have all the possibilities for a cell:
-                // - selected cell: green
-                // - cursor cell: blue
-                // - available move cell: grey
-                // - checked king cell: magenta
-                // - last move cell: green
-                // - default cell: white or black
-                // Draw the cell blue if this is the current cursor cell
-                if i == self.cursor_coordinates.row
-                    && j == self.cursor_coordinates.col
-                    && !self.mouse_used
-                    // When a piece is selected, only draw the cursor cell on "visible" ticks
-                    // so that it appears to flicker. On "hidden" ticks, we let the other
-                    // branches below (selected cell, available moves, etc.) handle the cell.
-                    && (!self.is_cell_selected() || self.cursor_blink_visible)
-                {
-                    let cursor_color = match self.display_mode {
-                        DisplayMode::CUSTOM => self.skin.cursor_color,
-                        _ => Color::LightBlue,
-                    };
-                    render_cell(frame, square, cursor_color, None);
-                }
-                // Draw the cell magenta if the king is getting checked
-                else if logic.game_board.is_getting_checked(logic.player_turn)
-                    && Coord::new(i, j) == logic.game_board.get_king_coordinates(logic.player_turn)
-                {
-                    render_cell(frame, square, Color::Magenta, Some(Modifier::SLOW_BLINK));
-                }
-                // Draw the cell green if this is the selected cell or if the cell is part of the last move
-                else if (i
-                    == get_coord_from_square(actual_square, logic.game_board.is_flipped).row
-                    && j == get_coord_from_square(actual_square, logic.game_board.is_flipped).col)
-                    || (last_move_from
-                        == get_square_from_coord(Coord::new(i, j), logic.game_board.is_flipped))
-                    || (last_move_to
-                        == get_square_from_coord(Coord::new(i, j), logic.game_board.is_flipped))
-                        && !is_cell_in_positions(&authorized_positions, i, j)
-                // and not in the authorized positions (grey instead of green)
-                {
-                    let highlight_color = match self.display_mode {
-                        DisplayMode::CUSTOM => {
-                            // Use selection color for selected square, last move color for last move
-                            if i == get_coord_from_square(
-                                actual_square,
-                                logic.game_board.is_flipped,
-                            )
-                            .row && j
-                                == get_coord_from_square(actual_square, logic.game_board.is_flipped)
-                                    .col
-                            {
-                                self.skin.selection_color
-                            } else {
-                                self.skin.last_move_color
-                            }
-                        }
-                        _ => Color::LightGreen,
-                    };
-                    render_cell(frame, square, highlight_color, None);
-                } else if is_cell_in_positions(&authorized_positions, i, j) {
-                    render_cell(frame, square, Color::Rgb(100, 100, 100), None);
-                }
-                // else as a last resort we draw the cell with the default color either white or black
-                else {
-                    let mut cell = Block::default();
-                    cell = match self.display_mode {
-                        DisplayMode::DEFAULT | DisplayMode::CUSTOM => cell.bg(cell_color),
-                        DisplayMode::ASCII => match cell_color {
-                            WHITE => cell.bg(Color::White).fg(Color::Black),
-                            BLACK => cell.bg(Color::Black).fg(Color::White),
-                            _ => cell.bg(cell_color),
-                        },
-                    };
-                    frame.render_widget(cell.clone(), square);
-                }
-
-                // Get piece and color
-                let coord = Coord::new(i, j);
-                let square_index =
-                    get_square_from_coord(coord, logic.game_board.is_flipped).unwrap();
-                let piece_color = logic.game_board.get_piece_color_at_square(&square_index);
-                let piece_type = logic.game_board.get_role_at_square(&square_index);
-
-                let paragraph = self.render_piece_paragraph(piece_type, piece_color, square);
-                frame.render_widget(paragraph, square);
+                let ctx = CellRenderContext {
+                    logic,
+                    i,
+                    j,
+                    square,
+                    actual_square,
+                    last_move_from,
+                    last_move_to,
+                    authorized_positions: &authorized_positions,
+                };
+                self.render_single_cell(frame, &ctx);
             }
+        }
+    }
+
+    /// Render a single cell of the board
+    fn render_single_cell(&self, frame: &mut Frame<'_>, ctx: &CellRenderContext<'_>) {
+        let CellRenderContext {
+            logic,
+            i,
+            j,
+            square,
+            actual_square,
+            last_move_from,
+            last_move_to,
+            authorized_positions,
+        } = *ctx;
+
+        // Color of the cell to draw the board
+        let cell_color: Color = if (i + j).is_multiple_of(2) {
+            match self.display_mode {
+                DisplayMode::CUSTOM => self.skin.board_white_color,
+                _ => WHITE,
+            }
+        } else {
+            match self.display_mode {
+                DisplayMode::CUSTOM => self.skin.board_black_color,
+                _ => BLACK,
+            }
+        };
+
+        let is_cell_in_positions = |positions: &[Coord], i: u8, j: u8| {
+            positions.iter().any(|&coord| coord == Coord::new(i, j))
+        };
+
+        // Here we have all the possibilities for a cell:
+        // - selected cell: green
+        // - cursor cell: blue
+        // - available move cell: grey
+        // - checked king cell: magenta
+        // - last move cell: green
+        // - default cell: white or black
+        // Draw the cell blue if this is the current cursor cell
+        if i == self.cursor_coordinates.row
+            && j == self.cursor_coordinates.col
+            && !self.mouse_used
+            // When a piece is selected, only draw the cursor cell on "visible" ticks
+            // so that it appears to flicker. On "hidden" ticks, we let the other
+            // branches below (selected cell, available moves, etc.) handle the cell.
+            && (!self.is_cell_selected() || self.cursor_blink_visible)
+        {
+            let cursor_color = match self.display_mode {
+                DisplayMode::CUSTOM => self.skin.cursor_color,
+                _ => Color::LightBlue,
+            };
+            render_cell(frame, square, cursor_color, None);
+        }
+        // Draw the cell magenta if the king is getting checked
+        else if logic.game_board.is_getting_checked(logic.player_turn)
+            && Coord::new(i, j) == logic.game_board.get_king_coordinates(logic.player_turn)
+        {
+            render_cell(frame, square, Color::Magenta, Some(Modifier::SLOW_BLINK));
+        }
+        // Draw the cell green if this is the selected cell or if the cell is part of the last move
+        else if (i == get_coord_from_square(actual_square, logic.game_board.is_flipped).row
+            && j == get_coord_from_square(actual_square, logic.game_board.is_flipped).col)
+            || (last_move_from
+                == get_square_from_coord(Coord::new(i, j), logic.game_board.is_flipped))
+            || (last_move_to
+                == get_square_from_coord(Coord::new(i, j), logic.game_board.is_flipped))
+                && !is_cell_in_positions(authorized_positions, i, j)
+        // and not in the authorized positions (grey instead of green)
+        {
+            let highlight_color = match self.display_mode {
+                DisplayMode::CUSTOM => {
+                    // Use selection color for selected square, last move color for last move
+                    if i == get_coord_from_square(actual_square, logic.game_board.is_flipped).row
+                        && j == get_coord_from_square(actual_square, logic.game_board.is_flipped).col
+                    {
+                        self.skin.selection_color
+                    } else {
+                        self.skin.last_move_color
+                    }
+                }
+                _ => Color::LightGreen,
+            };
+            render_cell(frame, square, highlight_color, None);
+        } else if is_cell_in_positions(authorized_positions, i, j) {
+            render_cell(frame, square, Color::Rgb(100, 100, 100), None);
+        }
+        // else as a last resort we draw the cell with the default color either white or black
+        else {
+            let mut cell = Block::default();
+            cell = match self.display_mode {
+                DisplayMode::DEFAULT | DisplayMode::CUSTOM => cell.bg(cell_color),
+                DisplayMode::ASCII => match cell_color {
+                    WHITE => cell.bg(Color::White).fg(Color::Black),
+                    BLACK => cell.bg(Color::Black).fg(Color::White),
+                    _ => cell.bg(cell_color),
+                },
+            };
+            frame.render_widget(cell.clone(), square);
+        }
+
+        // Get piece and color
+        let coord = Coord::new(i, j);
+        if let Some(square_index) = get_square_from_coord(coord, logic.game_board.is_flipped) {
+            let piece_color = logic.game_board.get_piece_color_at_square(&square_index);
+            let piece_type = logic.game_board.get_role_at_square(&square_index);
+
+            let paragraph = self.render_piece_paragraph(piece_type, piece_color, square);
+            frame.render_widget(paragraph, square);
         }
     }
 
@@ -895,7 +937,7 @@ impl UI {
             let file_area = layout[i];
             // Add minimal top padding to keep letters close to the board
             // Put most padding at the bottom for slight vertical centering
-            let top_padding = if file_area.height > 2 { 1 } else { 0 };
+            let top_padding = u16::from(file_area.height > 2);
             let bottom_padding = file_area.height.saturating_sub(1 + top_padding);
 
             // Create text with minimal top padding

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -116,7 +116,7 @@ fn handle_popup_input(app: &mut App, key_event: KeyEvent, popup: Popups) {
         },
         // End screen popup - shown when game ends (checkmate or draw)
         Popups::EndScreen => match key_event.code {
-            KeyCode::Char('h') | KeyCode::Char('H') => {
+            KeyCode::Char('h' | 'H') => {
                 // Hide the end screen (can be toggled back with H when not in popup)
                 app.current_popup = None;
                 app.end_screen_dismissed = true;
@@ -126,14 +126,14 @@ fn handle_popup_input(app: &mut App, key_event: KeyEvent, popup: Popups) {
                 app.current_popup = None;
                 app.end_screen_dismissed = true;
             }
-            KeyCode::Char('r') | KeyCode::Char('R') => {
+            KeyCode::Char('r' | 'R') => {
                 // Restart the game (only for non-multiplayer games)
                 if app.game.logic.opponent.is_none() {
                     app.restart();
                     app.current_popup = None;
                 }
             }
-            KeyCode::Char('b') | KeyCode::Char('B') => {
+            KeyCode::Char('b' | 'B') => {
                 // Go back to home menu - completely reset all game state
                 app.reset_home();
             }
@@ -141,7 +141,7 @@ fn handle_popup_input(app: &mut App, key_event: KeyEvent, popup: Popups) {
         },
         // Puzzle end screen popup - shown when puzzle is completed
         Popups::PuzzleEndScreen => match key_event.code {
-            KeyCode::Char('h') | KeyCode::Char('H') => {
+            KeyCode::Char('h' | 'H') => {
                 // Hide the puzzle end screen
                 app.current_popup = None;
             }
@@ -149,12 +149,12 @@ fn handle_popup_input(app: &mut App, key_event: KeyEvent, popup: Popups) {
                 // Also allow Esc to hide the puzzle end screen
                 app.current_popup = None;
             }
-            KeyCode::Char('n') | KeyCode::Char('N') => {
+            KeyCode::Char('n' | 'N') => {
                 // Start a new puzzle
                 app.current_popup = None;
                 app.start_puzzle_mode();
             }
-            KeyCode::Char('b') | KeyCode::Char('B') => {
+            KeyCode::Char('b' | 'B') => {
                 // Go back to home menu - completely reset all game state
                 app.reset_home();
             }

--- a/src/lichess.rs
+++ b/src/lichess.rs
@@ -5,8 +5,12 @@ use std::error::Error;
 use std::io::{BufRead, BufReader};
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const LICHESS_API_URL: &str = "https://lichess.org/api";
+const MAX_POLL_ATTEMPTS: usize = 30;
+const POLL_INTERVAL_MS: u64 = 1000;
+const MAX_LINES: usize = 100;
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
@@ -206,6 +210,7 @@ pub struct LichessClient {
 }
 
 impl LichessClient {
+    #[must_use]
     pub fn new(token: String) -> Self {
         Self {
             token,
@@ -217,8 +222,13 @@ impl LichessClient {
         }
     }
 
+    /// Get the user's profile from Lichess.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails or the response is invalid.
     pub fn get_my_profile(&self) -> Result<String, Box<dyn Error>> {
-        let url = format!("{}/account", LICHESS_API_URL);
+        let url = format!("{LICHESS_API_URL}/account");
         let response = self
             .client
             .get(&url)
@@ -230,16 +240,22 @@ impl LichessClient {
             .send()?;
 
         if !response.status().is_success() {
-            return Err(format!("Failed to fetch profile: {}", response.status()).into());
+            let status = response.status();
+            return Err(format!("Failed to fetch profile: {status}").into());
         }
 
         let player: Player = response.json()?;
         player.id.ok_or("Profile missing ID".into())
     }
 
+    /// Get the user's detailed profile from Lichess.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails or the response is invalid.
     pub fn get_user_profile(&self) -> Result<UserProfile, Box<dyn Error>> {
-        let url = format!("{}/account", LICHESS_API_URL);
-        log::info!("Fetching user profile from: {}", url);
+        let url = format!("{LICHESS_API_URL}/account");
+        log::info!("Fetching user profile from: {url}");
 
         let response = self
             .client
@@ -252,7 +268,8 @@ impl LichessClient {
             .send()?;
 
         if !response.status().is_success() {
-            return Err(format!("Failed to fetch user profile: {}", response.status()).into());
+            let status = response.status();
+            return Err(format!("Failed to fetch user profile: {status}").into());
         }
 
         let profile: UserProfile = response.json()?;
@@ -260,9 +277,14 @@ impl LichessClient {
         Ok(profile)
     }
 
+    /// Get the user's ongoing games from Lichess.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails or the response is invalid.
     pub fn get_ongoing_games(&self) -> Result<Vec<OngoingGame>, Box<dyn Error>> {
-        let url = format!("{}/account/playing", LICHESS_API_URL);
-        log::info!("Fetching ongoing games from: {}", url);
+        let url = format!("{LICHESS_API_URL}/account/playing");
+        log::info!("Fetching ongoing games from: {url}");
 
         let response = self
             .client
@@ -278,7 +300,8 @@ impl LichessClient {
             if response.status() == reqwest::StatusCode::UNAUTHORIZED {
                 return Err("Invalid token. Please check your token or generate a new one.".into());
             }
-            return Err(format!("Failed to fetch ongoing games: {}", response.status()).into());
+            let status = response.status();
+            return Err(format!("Failed to fetch ongoing games: {status}").into());
         }
 
         let games_response: OngoingGamesResponse = response.json()?;
@@ -286,17 +309,21 @@ impl LichessClient {
         Ok(games_response.now_playing)
     }
 
+    /// Get the next puzzle from Lichess.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails or the response is invalid.
     pub fn get_next_puzzle(&self) -> Result<Puzzle, Box<dyn Error>> {
         // Use /puzzle/next but add a cache-busting parameter to ensure we get a new puzzle
         // Adding a timestamp parameter forces the server to return a fresh puzzle
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let _timestamp = SystemTime::now()
+        let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis();
-        let url = format!("{}/puzzle/next?t={}", LICHESS_API_URL, _timestamp);
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+        let url = format!("{LICHESS_API_URL}/puzzle/next?t={timestamp}");
 
-        log::info!("Fetching puzzle from: {}", url);
+        log::info!("Fetching puzzle from: {url}");
 
         let response = self
             .client
@@ -309,7 +336,8 @@ impl LichessClient {
             .send()?;
 
         if !response.status().is_success() {
-            return Err(format!("Failed to fetch puzzle: {}", response.status()).into());
+            let status = response.status();
+            return Err(format!("Failed to fetch puzzle: {status}").into());
         }
 
         let puzzle: Puzzle = response.json()?;
@@ -322,8 +350,12 @@ impl LichessClient {
     }
 
     /// Submit puzzle result to Lichess
-    /// According to https://lichess.org/api#tag/puzzles/post/apipuzzlebatchangle
+    /// According to <https://lichess.org/api#tag/puzzles/post/apipuzzlebatchangle>
     /// This endpoint expects a JSON body with puzzle results
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails.
     pub fn submit_puzzle_result(
         &self,
         puzzle_id: &str,
@@ -342,10 +374,10 @@ impl LichessClient {
             }]
         });
 
-        let url = format!("{}/puzzle/batch/angle", LICHESS_API_URL);
+        let url = format!("{LICHESS_API_URL}/puzzle/batch/angle");
         log::info!("=== SUBMITTING PUZZLE RESULT ===");
-        log::info!("URL: {}", url);
-        log::info!("Puzzle ID: {}, Win: {}, Time: {:?}ms", puzzle_id, win, time);
+        log::info!("URL: {url}");
+        log::info!("Puzzle ID: {puzzle_id}, Win: {win}, Time: {time:?}ms");
         log::info!(
             "Payload: {}",
             serde_json::to_string_pretty(&payload).unwrap_or_default()
@@ -366,20 +398,12 @@ impl LichessClient {
         let status = response.status();
         let response_text = response.text().unwrap_or_default();
 
-        log::info!("Response status: {}", status);
-        log::info!("Response body: {}", response_text);
+        log::info!("Response status: {status}");
+        log::info!("Response body: {response_text}");
 
         if !status.is_success() {
-            log::error!(
-                "Failed to submit puzzle result: {} - {}",
-                status,
-                response_text
-            );
-            return Err(format!(
-                "Failed to submit puzzle result: {} - {}",
-                status, response_text
-            )
-            .into());
+            log::error!("Failed to submit puzzle result: {status} - {response_text}");
+            return Err(format!("Failed to submit puzzle result: {status} - {response_text}").into());
         }
 
         log::info!("✓ Puzzle result submitted successfully to Lichess!");
@@ -388,10 +412,14 @@ impl LichessClient {
 
     /// Get puzzle activity from Lichess API
     /// Returns the most recent puzzle attempts with rating changes
-    /// See: https://lichess.org/api#tag/puzzles/get/apipuzzleactivity
+    /// See: <https://lichess.org/api#tag/puzzles/get/apipuzzleactivity>
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails or the response is invalid.
     pub fn get_puzzle_activity(&self) -> Result<Vec<PuzzleActivity>, Box<dyn Error>> {
-        let url = format!("{}/puzzle/activity", LICHESS_API_URL);
-        log::info!("Fetching puzzle activity from: {}", url);
+        let url = format!("{LICHESS_API_URL}/puzzle/activity");
+        log::info!("Fetching puzzle activity from: {url}");
 
         let response = self
             .client
@@ -404,7 +432,8 @@ impl LichessClient {
             .send()?;
 
         if !response.status().is_success() {
-            return Err(format!("Failed to fetch puzzle activity: {}", response.status()).into());
+            let status = response.status();
+            return Err(format!("Failed to fetch puzzle activity: {status}").into());
         }
 
         // The API returns NDJSON (newline-delimited JSON)
@@ -419,7 +448,7 @@ impl LichessClient {
             match serde_json::from_str::<PuzzleActivity>(&line) {
                 Ok(activity) => activities.push(activity),
                 Err(e) => {
-                    log::warn!("Failed to parse puzzle activity line: {} - {}", line, e);
+                    log::warn!("Failed to parse puzzle activity line: {line} - {e}");
                 }
             }
         }
@@ -431,10 +460,11 @@ impl LichessClient {
     fn spawn_seek_background_poll(
         &self,
         initial_game_ids: std::collections::HashSet<String>,
-        cancellation_token: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        cancellation_token: &std::sync::Arc<std::sync::atomic::AtomicBool>,
         game_found_tx: Sender<Result<(String, Color), String>>,
     ) {
         let token = self.token.clone();
+        let cancellation_token = cancellation_token.clone();
 
         thread::spawn(move || {
             log::info!("Starting background polling thread for ongoing games");
@@ -451,7 +481,7 @@ impl LichessClient {
 
                 std::thread::sleep(std::time::Duration::from_secs(2)); // Poll every 2 seconds
 
-                let poll_url = format!("{}/account/playing", LICHESS_API_URL);
+                let poll_url = format!("{LICHESS_API_URL}/account/playing");
                 match poll_client
                     .get(&poll_url)
                     .header(
@@ -465,7 +495,7 @@ impl LichessClient {
                         if response.status().is_success() {
                             if let Ok(games_response) = response.json::<OngoingGamesResponse>() {
                                 // Find a new game that wasn't in our initial list
-                                for game in games_response.now_playing.iter() {
+                                for game in &games_response.now_playing {
                                     if !initial_game_ids.contains(&game.game_id) {
                                         let color = if game.color == "white" {
                                             Color::White
@@ -473,9 +503,8 @@ impl LichessClient {
                                             Color::Black
                                         };
                                         log::info!(
-                                            "Background poll found new game: {} as {:?}",
-                                            game.game_id,
-                                            color
+                                            "Background poll found new game: {} as {color:?}",
+                                            game.game_id
                                         );
                                         let _ =
                                             game_found_tx.send(Ok((game.game_id.clone(), color)));
@@ -486,21 +515,26 @@ impl LichessClient {
                         }
                     }
                     Err(e) => {
-                        log::debug!("Background poll error (non-fatal): {}", e);
+                        log::debug!("Background poll error (non-fatal): {e}");
                     }
                 }
             }
         });
     }
 
+    /// Seek a game on Lichess with specified time controls.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the seek is cancelled, the API request fails, or the game cannot be found.
     pub fn seek_game(
         &self,
         time: u32,
         increment: u32,
-        cancellation_token: std::sync::Arc<std::sync::atomic::AtomicBool>,
-        my_id: String,
+        cancellation_token: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+        my_id: &str,
     ) -> Result<(String, Color), Box<dyn Error>> {
-        let url = format!("{}/board/seek", LICHESS_API_URL);
+        let url = format!("{LICHESS_API_URL}/board/seek");
 
         // For correspondence games (time=0), use days parameter instead
         let params = if time == 0 && increment == 0 {
@@ -548,7 +582,7 @@ impl LichessClient {
             if !status.is_success() {
                 // Try to get error details from response body
                 let error_text = response.text().unwrap_or_default();
-                log::error!("Seek request failed: {} - {}", status, error_text);
+                log::error!("Seek request failed: {status} - {error_text}");
 
                 if status == reqwest::StatusCode::FORBIDDEN {
                     return Err("Token missing permissions. Please generate a new token with 'board:play' scope enabled.".into());
@@ -564,9 +598,9 @@ impl LichessClient {
                     );
                 }
                 if status == reqwest::StatusCode::BAD_REQUEST {
-                    return Err(format!("Invalid seek parameters: {}. The board/seek endpoint may not support correspondence games (0+0). Try using a longer time control instead.", error_text).into());
+                    return Err(format!("Invalid seek parameters: {error_text}. The board/seek endpoint may not support correspondence games (0+0). Try using a longer time control instead.").into());
                 }
-                return Err(format!("Failed to seek game: {} - {}", status, error_text).into());
+                return Err(format!("Failed to seek game: {status} - {error_text}").into());
             }
 
             log::info!("Connected to seek endpoint. Status: {}", response.status());
@@ -578,7 +612,7 @@ impl LichessClient {
 
             self.spawn_seek_background_poll(
                 initial_game_ids.clone(),
-                cancellation_token.clone(),
+                cancellation_token,
                 game_found_tx,
             );
 
@@ -595,7 +629,7 @@ impl LichessClient {
                 match game_found_rx.try_recv() {
                     Ok(result) => {
                         log::info!("Game found via background polling");
-                        return result.map_err(|e| e.into());
+                        return result.map_err(Into::into);
                     }
                     Err(std::sync::mpsc::TryRecvError::Empty) => {
                         // No game found yet, continue reading stream
@@ -607,18 +641,15 @@ impl LichessClient {
 
                 log::debug!("Reading line from stream...");
                 let line = line?;
-                log::debug!("Received raw line: '{}'", line);
+                log::debug!("Received raw line: '{line}'");
 
                 if line.trim().is_empty() {
                     empty_line_count += 1;
                     // After every 5 empty lines (10 seconds of keep-alive), check ongoing games
                     if empty_line_count % 5 == 0 {
-                        log::debug!(
-                            "Checking ongoing games after {} empty lines",
-                            empty_line_count
-                        );
+                        log::debug!("Checking ongoing games after {empty_line_count} empty lines");
                         if let Ok(ongoing_games) = self.get_ongoing_games() {
-                            for game in ongoing_games.iter() {
+                            for game in &ongoing_games {
                                 if !initial_game_ids.contains(&game.game_id) {
                                     let color = if game.color == "white" {
                                         Color::White
@@ -626,9 +657,8 @@ impl LichessClient {
                                         Color::Black
                                     };
                                     log::info!(
-                                        "Found new game in ongoing games (during stream): {} as {:?}",
-                                        game.game_id,
-                                        color
+                                        "Found new game in ongoing games (during stream): {} as {color:?}",
+                                        game.game_id
                                     );
                                     return Ok((game.game_id.clone(), color));
                                 }
@@ -641,7 +671,7 @@ impl LichessClient {
                 empty_line_count = 0; // Reset counter on non-empty line
 
                 // The seek endpoint streams game events, starting with gameFull
-                log::info!("Received Lichess event: {}", line);
+                log::info!("Received Lichess event: {line}");
 
                 // Try to parse as GameEvent first
                 match serde_json::from_str::<GameEvent>(&line) {
@@ -653,12 +683,12 @@ impl LichessClient {
                                 black: _black,
                                 ..
                             } => {
-                                let color = if white.id.as_ref() == Some(&my_id) {
+                                let color = if white.id.as_deref() == Some(my_id) {
                                     Color::White
                                 } else {
                                     Color::Black
                                 };
-                                log::info!("Got GameFull event with game ID: {}", id);
+                                log::info!("Got GameFull event with game ID: {id}");
                                 return Ok((id, color));
                             }
                             GameEvent::GameState(_) => {
@@ -668,7 +698,6 @@ impl LichessClient {
                             }
                             GameEvent::ChatLine => {
                                 // Ignore chat lines
-                                continue;
                             }
                         }
                     }
@@ -677,7 +706,7 @@ impl LichessClient {
                         if let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) {
                             // Check if this JSON has an "id" field (might be gameFull without proper structure)
                             if let Some(id) = json.get("id").and_then(|v| v.as_str()) {
-                                log::info!("Found game ID in JSON: {}", id);
+                                log::info!("Found game ID in JSON: {id}");
                                 game_id_from_stream = Some(id.to_string());
                                 // Try to determine color from the JSON
                                 if let Some(white) = json.get("white") {
@@ -694,9 +723,7 @@ impl LichessClient {
                             }
                         } else {
                             log::warn!(
-                                "Failed to parse event as GameEvent or JSON: {} - Error: {}",
-                                line,
-                                e
+                                "Failed to parse event as GameEvent or JSON: {line} - Error: {e}"
                             );
                         }
                     }
@@ -705,10 +732,7 @@ impl LichessClient {
 
             // Stream ended - check if we got a game ID from the stream
             if let Some(game_id) = game_id_from_stream {
-                log::info!(
-                    "Stream ended but we have game ID: {}, checking ongoing games",
-                    game_id
-                );
+                log::info!("Stream ended but we have game ID: {game_id}, checking ongoing games");
                 // Check ongoing games to get the color
                 if let Ok(ongoing_games) = self.get_ongoing_games() {
                     if let Some(game) = ongoing_games.iter().find(|g| g.game_id == game_id) {
@@ -718,9 +742,7 @@ impl LichessClient {
                             Color::Black
                         };
                         log::info!(
-                            "Found game in ongoing games after stream ended: {} as {:?}",
-                            game_id,
-                            color
+                            "Found game in ongoing games after stream ended: {game_id} as {color:?}"
                         );
                         return Ok((game_id, color));
                     }
@@ -731,7 +753,7 @@ impl LichessClient {
             log::info!("Stream ended without gameFull event, checking ongoing games...");
             if let Ok(ongoing_games) = self.get_ongoing_games() {
                 // Find a new game that wasn't in our initial list
-                for game in ongoing_games.iter() {
+                for game in &ongoing_games {
                     if !initial_game_ids.contains(&game.game_id) {
                         let color = if game.color == "white" {
                             Color::White
@@ -739,9 +761,8 @@ impl LichessClient {
                             Color::Black
                         };
                         log::info!(
-                            "Found new game in ongoing games: {} as {:?}",
-                            game.game_id,
-                            color
+                            "Found new game in ongoing games: {} as {color:?}",
+                            game.game_id
                         );
                         return Ok((game.game_id.clone(), color));
                     }
@@ -763,7 +784,7 @@ impl LichessClient {
 
                 if let Ok(ongoing_games) = self.get_ongoing_games() {
                     // Find a new game that wasn't in our initial list
-                    for game in ongoing_games.iter() {
+                    for game in &ongoing_games {
                         if !initial_game_ids.contains(&game.game_id) {
                             let color = if game.color == "white" {
                                 Color::White
@@ -771,9 +792,8 @@ impl LichessClient {
                                 Color::Black
                             };
                             log::info!(
-                                "Found new game via polling: {} as {:?}",
-                                game.game_id,
-                                color
+                                "Found new game via polling: {} as {color:?}",
+                                game.game_id
                             );
                             return Ok((game.game_id.clone(), color));
                         }
@@ -786,12 +806,13 @@ impl LichessClient {
         }
     }
 
-    pub fn join_game(
-        &self,
-        game_id: &str,
-        my_id: String,
-    ) -> Result<(String, Color), Box<dyn Error>> {
-        log::info!("Attempting to join game: {}", game_id);
+    /// Join an existing game on Lichess.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the game cannot be found or joined.
+    pub fn join_game(&self, game_id: &str, my_id: &str) -> Result<(String, Color), Box<dyn Error>> {
+        log::info!("Attempting to join game: {game_id}");
 
         // First, try to get the game from ongoing games (for already-started games)
         if let Ok(ongoing_games) = self.get_ongoing_games() {
@@ -801,14 +822,14 @@ impl LichessClient {
                 } else {
                     Color::Black
                 };
-                log::info!("Found game in ongoing games: {} as {:?}", game_id, color);
+                log::info!("Found game in ongoing games: {game_id} as {color:?}");
                 return Ok((game_id.to_string(), color));
             }
         }
 
         // If not in ongoing games, try to accept the challenge in case it hasn't been accepted yet
-        log::info!("Attempting to accept challenge: {}", game_id);
-        let accept_url = format!("{}/challenge/{}/accept", LICHESS_API_URL, game_id);
+        log::info!("Attempting to accept challenge: {game_id}");
+        let accept_url = format!("{LICHESS_API_URL}/challenge/{game_id}/accept");
         let accept_response = self
             .client
             .post(&accept_url)
@@ -837,10 +858,7 @@ impl LichessClient {
                 }
             }
             Err(e) => {
-                log::warn!(
-                    "Failed to accept challenge: {}, will try to stream game anyway",
-                    e
-                );
+                log::warn!("Failed to accept challenge: {e}, will try to stream game anyway");
                 false
             }
         };
@@ -852,9 +870,6 @@ impl LichessClient {
 
         // Wait for the game to appear in ongoing games or be streamable
         // Poll for up to 30 seconds (for challenges that need to be accepted)
-        const MAX_POLL_ATTEMPTS: usize = 30;
-        const POLL_INTERVAL_MS: u64 = 1000;
-
         for attempt in 0..MAX_POLL_ATTEMPTS {
             // Check ongoing games first
             if let Ok(ongoing_games) = self.get_ongoing_games() {
@@ -864,17 +879,13 @@ impl LichessClient {
                     } else {
                         Color::Black
                     };
-                    log::info!(
-                        "Found game in ongoing games after polling: {} as {:?}",
-                        game_id,
-                        color
-                    );
+                    log::info!("Found game in ongoing games after polling: {game_id} as {color:?}");
                     return Ok((game_id.to_string(), color));
                 }
             }
 
             // Try to stream the game
-            let url = format!("{}/board/game/{}/stream", LICHESS_API_URL, game_id);
+            let url = format!("{LICHESS_API_URL}/board/game/{game_id}/stream");
             let response = match self
                 .client
                 .get(&url)
@@ -899,9 +910,8 @@ impl LichessClient {
                                     POLL_INTERVAL_MS,
                                 ));
                                 continue;
-                            } else {
-                                return Err("Game not found or hasn't started yet. Make sure the challenge has been accepted by your opponent.".into());
                             }
+                            return Err("Game not found or hasn't started yet. Make sure the challenge has been accepted by your opponent.".into());
                         }
                         if resp.status() == reqwest::StatusCode::FORBIDDEN {
                             return Err(
@@ -914,18 +924,18 @@ impl LichessClient {
                                     .into(),
                             );
                         }
-                        return Err(format!("Failed to join game: {}", resp.status()).into());
+                        let status = resp.status();
+                        return Err(format!("Failed to join game: {status}").into());
                     }
                     resp
                 }
                 Err(e) => {
-                    log::warn!("Failed to connect to stream: {}, will retry", e);
+                    log::warn!("Failed to connect to stream: {e}, will retry");
                     if attempt < MAX_POLL_ATTEMPTS - 1 {
                         std::thread::sleep(std::time::Duration::from_millis(POLL_INTERVAL_MS));
                         continue;
-                    } else {
-                        return Err(format!("Failed to connect to game stream: {}", e).into());
                     }
+                    return Err(format!("Failed to connect to game stream: {e}").into());
                 }
             };
 
@@ -933,7 +943,6 @@ impl LichessClient {
 
             let reader = BufReader::new(response);
             let mut line_count = 0;
-            const MAX_LINES: usize = 100; // Limit to prevent infinite loop
 
             for line in reader.lines() {
                 let line = line?;
@@ -947,7 +956,7 @@ impl LichessClient {
                     continue;
                 }
 
-                log::info!("Received game event: {}", line);
+                log::info!("Received game event: {line}");
                 match serde_json::from_str::<GameEvent>(&line) {
                     Ok(event) => {
                         if let GameEvent::GameFull {
@@ -955,15 +964,15 @@ impl LichessClient {
                         } = event
                         {
                             // Determine our color based on player IDs
-                            let color = if white.id.as_ref() == Some(&my_id) {
+                            let color = if white.id.as_deref() == Some(my_id) {
                                 Color::White
-                            } else if black.id.as_ref() == Some(&my_id) {
+                            } else if black.id.as_deref() == Some(my_id) {
                                 Color::Black
                             } else {
                                 return Err("You are not a participant in this game.".into());
                             };
 
-                            log::info!("Successfully joined game {} as {:?}", id, color);
+                            log::info!("Successfully joined game {id} as {color:?}");
                             return Ok((id, color));
                         }
                         // For already-started games, we might only get GameState events
@@ -981,9 +990,7 @@ impl LichessClient {
                                         Color::Black
                                     };
                                     log::info!(
-                                        "Found game in ongoing games after GameState: {} as {:?}",
-                                        game_id,
-                                        color
+                                        "Found game in ongoing games after GameState: {game_id} as {color:?}"
                                     );
                                     return Ok((game_id.to_string(), color));
                                 }
@@ -993,7 +1000,7 @@ impl LichessClient {
                         }
                     }
                     Err(e) => {
-                        log::error!("Failed to parse event: {} - Error: {}", line, e);
+                        log::error!("Failed to parse event: {line} - Error: {e}");
                     }
                 }
             }
@@ -1013,14 +1020,18 @@ impl LichessClient {
     }
 
     /// Get turn count and last move from public API
-    /// Returns (turn_count, last_move) - useful when setting up a game
+    /// Returns (`turn_count`, `last_move`) - useful when setting up a game
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails or the response is invalid.
     pub fn get_game_turn_count_and_last_move(
         &self,
         game_id: &str,
     ) -> Result<(usize, Option<String>), Box<dyn Error>> {
         // Use public stream endpoint /api/stream/game/{id} (same as polling)
         // Read the first line (gameFull event), then close the stream
-        let url = format!("{}/stream/game/{}", LICHESS_API_URL, game_id);
+        let url = format!("{LICHESS_API_URL}/stream/game/{game_id}");
         let response = self
             .client
             .get(&url)
@@ -1031,7 +1042,8 @@ impl LichessClient {
             .send()?;
 
         if !response.status().is_success() {
-            return Err(format!("Failed to get game info: {}", response.status()).into());
+            let status = response.status();
+            return Err(format!("Failed to get game info: {status}").into());
         }
 
         // Read the first line which should be the gameFull event
@@ -1042,24 +1054,23 @@ impl LichessClient {
             }
 
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) {
-                log::info!("Game info JSON: {:?}", json);
+                log::info!("Game info JSON: {json:?}");
                 // Extract turns (number of half-moves)
+                // Note: truncation is acceptable here as turn counts won't exceed usize
                 let turns = json
                     .get("turns")
-                    .and_then(|v| v.as_u64())
-                    .map(|v| v as usize)
-                    .unwrap_or(0);
+                    .and_then(serde_json::Value::as_u64)
+                    .map_or(0, |v| v as usize);
 
                 // Extract last move
                 let last_move = json
                     .get("lastMove")
                     .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+                    .map(ToString::to_string);
 
                 return Ok((turns, last_move));
-            } else {
-                return Err("Failed to parse JSON from stream".into());
             }
+            return Err("Failed to parse JSON from stream".into());
         }
 
         Err("No data received from stream".into())
@@ -1075,10 +1086,7 @@ impl LichessClient {
         let client: Client = self.client.clone();
 
         thread::spawn(move || {
-            log::info!(
-                "Starting polling thread for Lichess game {} (polling every 3 seconds)",
-                game_id
-            );
+            log::info!("Starting polling thread for Lichess game {game_id} (polling every 3 seconds)");
             let mut last_turns: Option<usize> = None;
             let mut last_move_seen: Option<String> = None;
             let mut last_status: Option<String> = None;
@@ -1099,11 +1107,11 @@ impl LichessClient {
                 }
 
                 // Always poll to detect moves made on the Lichess website, even when it's the player's turn
-                log::debug!("Polling game {}...", game_id);
+                log::debug!("Polling game {game_id}...");
 
                 // Use public stream endpoint to get current game state with moves
                 // We'll connect, read the first line (gameFull event), then close
-                let poll_url = format!("{}/stream/game/{}", LICHESS_API_URL, game_id);
+                let poll_url = format!("{LICHESS_API_URL}/stream/game/{game_id}");
                 match client
                     .get(&poll_url)
                     .header(
@@ -1114,13 +1122,13 @@ impl LichessClient {
                 {
                     Ok(response) => {
                         let status = response.status();
-                        log::debug!("Poll response status: {}", status);
+                        log::debug!("Poll response status: {status}");
 
                         if !status.is_success() {
-                            log::warn!("Poll failed with status: {}", status);
+                            log::warn!("Poll failed with status: {status}");
                             // If game not found or ended, stop polling
                             if status == reqwest::StatusCode::NOT_FOUND {
-                                log::info!("Game {} not found, stopping poll", game_id);
+                                log::info!("Game {game_id} not found, stopping poll");
                                 break;
                             }
                             continue;
@@ -1133,7 +1141,7 @@ impl LichessClient {
                                 continue;
                             }
 
-                            log::debug!("Poll received line: {}", line);
+                            log::debug!("Poll received line: {line}");
 
                             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) {
                                 // Check if this is a gameFull event (has fen and turns fields)
@@ -1144,7 +1152,7 @@ impl LichessClient {
                                         .get("status")
                                         .and_then(|s| s.get("name"))
                                         .and_then(|n| n.as_str())
-                                        .map(|s| s.to_string());
+                                        .map(ToString::to_string);
 
                                     if let Some(ref status) = current_status {
                                         // Check if status changed to indicate game end (or if this is the first poll)
@@ -1152,9 +1160,7 @@ impl LichessClient {
 
                                         if is_status_change {
                                             log::info!(
-                                                "Game status: {:?} -> {:?}",
-                                                last_status,
-                                                status
+                                                "Game status: {last_status:?} -> {status:?}"
                                             );
 
                                             // Check if the game has ended (or was already ended when we joined)
@@ -1166,7 +1172,7 @@ impl LichessClient {
                                                 }
                                                 "draw" | "stalemate" | "repetition"
                                                 | "insufficient" | "fifty" => {
-                                                    log::info!("Game ended by draw ({}), sending status update", status);
+                                                    log::info!("Game ended by draw ({status}), sending status update");
                                                     let _ = move_tx
                                                         .send("GAME_STATUS:draw".to_string());
                                                 }
@@ -1191,11 +1197,11 @@ impl LichessClient {
                                                     }
                                                 }
                                                 _ => {
-                                                    log::debug!("Unknown game status: {}", status);
+                                                    log::debug!("Unknown game status: {status}");
                                                 }
                                             }
 
-                                            last_status = current_status.clone();
+                                            last_status.clone_from(&current_status);
                                         }
                                     } else if last_status.is_none() {
                                         // If we can't get status but haven't seen one yet, log it
@@ -1206,12 +1212,12 @@ impl LichessClient {
                                     // Extract turns count on first poll
                                     if last_turns.is_none() {
                                         if let Some(turns) =
-                                            json.get("turns").and_then(|v| v.as_u64())
+                                            json.get("turns").and_then(serde_json::Value::as_u64)
                                         {
+                                            // Note: truncation is acceptable here
                                             let turns_usize = turns as usize;
                                             log::info!(
-                                                "Initial poll: {} turns (half-moves)",
-                                                turns_usize
+                                                "Initial poll: {turns_usize} turns (half-moves)"
                                             );
                                             last_turns = Some(turns_usize);
 
@@ -1228,9 +1234,7 @@ impl LichessClient {
                                                 {
                                                     let last_move = last_move_str.to_string();
                                                     log::info!(
-                                                        "First poll detected existing move: {} (turns: {}) - sending before INIT_MOVES",
-                                                        last_move,
-                                                        turns_usize
+                                                        "First poll detected existing move: {last_move} (turns: {turns_usize}) - sending before INIT_MOVES"
                                                     );
                                                     // Send the move FIRST
                                                     let last_move_clone = last_move.clone();
@@ -1242,20 +1246,19 @@ impl LichessClient {
                                             // Send initial move count AFTER the move (if any)
                                             // This ensures the move is processed first, then INIT_MOVES updates the counters
                                             let _ =
-                                                move_tx.send(format!("INIT_MOVES:{}", turns_usize));
+                                                move_tx.send(format!("INIT_MOVES:{turns_usize}"));
                                         }
                                     } else {
                                         // Check for new moves by comparing turns
                                         // The public stream doesn't provide a moves string, but has lastMove
+                                        // Note: truncation is acceptable here
                                         let current_turns = json
                                             .get("turns")
-                                            .and_then(|v| v.as_u64())
+                                            .and_then(serde_json::Value::as_u64)
                                             .map(|v| v as usize);
 
                                         log::debug!(
-                                            "Current turns: {:?}, Last turns: {:?}",
-                                            current_turns,
-                                            last_turns
+                                            "Current turns: {current_turns:?}, Last turns: {last_turns:?}"
                                         );
 
                                         // The public stream doesn't provide a moves string, but has lastMove
@@ -1290,13 +1293,11 @@ impl LichessClient {
                                                     if (from_file == 'a' || from_file == 'h')
                                                         && (from_rank == '1' || from_rank == '8')
                                                     {
-                                                        log::info!("ROOK MOVE detected in poll: {} (turns: {:?})", last_move, current_turns);
+                                                        log::info!("ROOK MOVE detected in poll: {last_move} (turns: {current_turns:?})");
                                                     }
                                                 }
                                                 log::info!(
-                                                    "Poll detected new move: {} (turns: {:?})",
-                                                    last_move,
-                                                    current_turns
+                                                    "Poll detected new move: {last_move} (turns: {current_turns:?})"
                                                 );
                                                 let _ = move_tx.send(last_move.clone());
                                                 last_move_seen = Some(last_move.clone());
@@ -1307,9 +1308,7 @@ impl LichessClient {
                                                 }
                                             } else {
                                                 log::debug!(
-                                                    "No new moves detected (turns: {:?}, lastMove unchanged: {})",
-                                                    current_turns,
-                                                    last_move
+                                                    "No new moves detected (turns: {current_turns:?}, lastMove unchanged: {last_move})"
                                                 );
                                             }
 
@@ -1380,20 +1379,25 @@ impl LichessClient {
                                     log::debug!("Poll response is not a gameFull event (no 'fen' or 'turns' field)");
                                 }
                             } else {
-                                log::warn!("Failed to parse poll response as JSON: {}", line);
+                                log::warn!("Failed to parse poll response as JSON: {line}");
                             }
                         }
                     }
                     Err(e) => {
-                        log::warn!("Poll request failed: {}", e);
+                        log::warn!("Poll request failed: {e}");
                         // Continue polling even if one request fails
                     }
                 }
             }
-            log::info!("Polling thread ended for game {}", game_id);
+            log::info!("Polling thread ended for game {game_id}");
         });
     }
 
+    /// Stream a game from Lichess, receiving moves via the provided channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the game ID is empty.
     pub fn stream_game(
         &self,
         game_id: String,
@@ -1415,24 +1419,31 @@ impl LichessClient {
         Ok(())
     }
 
+    /// Make a move in an ongoing game.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails.
     pub fn make_move(&self, game_id: &str, move_str: &str) -> Result<(), Box<dyn Error>> {
-        let url = format!(
-            "{}/board/game/{}/move/{}",
-            LICHESS_API_URL, game_id, move_str
-        );
+        let url = format!("{LICHESS_API_URL}/board/game/{game_id}/move/{move_str}");
         let response = self.client.post(&url).bearer_auth(&self.token).send()?;
 
         if !response.status().is_success() {
-            return Err(format!("Failed to make move: {}", response.status()).into());
+            let status = response.status();
+            return Err(format!("Failed to make move: {status}").into());
         }
         Ok(())
     }
 
     /// Resign a game
     /// Uses the board API endpoint /board/game/{id}/resign
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the API request fails.
     pub fn resign_game(&self, game_id: &str) -> Result<(), Box<dyn Error>> {
-        let url = format!("{}/board/game/{}/resign", LICHESS_API_URL, game_id);
-        log::info!("Resigning game: {}", game_id);
+        let url = format!("{LICHESS_API_URL}/board/game/{game_id}/resign");
+        log::info!("Resigning game: {game_id}");
 
         let response = self
             .client
@@ -1447,11 +1458,11 @@ impl LichessClient {
         if !response.status().is_success() {
             let status = response.status();
             let error_text = response.text().unwrap_or_default();
-            log::error!("Failed to resign game: {} - {}", status, error_text);
-            return Err(format!("Failed to resign game: {} - {}", status, error_text).into());
+            log::error!("Failed to resign game: {status} - {error_text}");
+            return Err(format!("Failed to resign game: {status} - {error_text}").into());
         }
 
-        log::info!("Successfully resigned game: {}", game_id);
+        log::info!("Successfully resigned game: {game_id}");
         Ok(())
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -4,6 +4,14 @@ use simplelog::{CombinedLogger, Config, WriteLogger};
 use std::fs;
 use std::path::Path;
 
+/// Sets up logging for the application.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The logs directory cannot be created
+/// - The log file cannot be created
+/// - The logger initialization fails
 pub fn setup_logging(
     config_dir: &Path,
     log_level: &LevelFilter,
@@ -17,7 +25,7 @@ pub fn setup_logging(
 
             // Create log file with timestamp
             let timestamp = Local::now().format("%Y-%m-%d_%H-%M-%S");
-            let log_file = log_dir.join(format!("chess-tui_{}.log", timestamp));
+            let log_file = log_dir.join(format!("chess-tui_{timestamp}.log"));
 
             CombinedLogger::init(vec![WriteLogger::new(
                 *level,

--- a/src/pieces/bishop.rs
+++ b/src/pieces/bishop.rs
@@ -5,6 +5,7 @@ use shakmaty::Color;
 pub struct Bishop;
 
 impl Bishop {
+    #[must_use]
     pub fn to_string(display_mode: &DisplayMode, size: PieceSize, color: Option<Color>) -> String {
         match display_mode {
             DisplayMode::DEFAULT | DisplayMode::CUSTOM => match size {

--- a/src/pieces/king.rs
+++ b/src/pieces/king.rs
@@ -5,6 +5,7 @@ use shakmaty::Color;
 pub struct King;
 
 impl King {
+    #[must_use]
     pub fn to_string(display_mode: &DisplayMode, size: PieceSize, color: Option<Color>) -> String {
         match display_mode {
             DisplayMode::DEFAULT | DisplayMode::CUSTOM => match size {

--- a/src/pieces/knight.rs
+++ b/src/pieces/knight.rs
@@ -5,6 +5,7 @@ use shakmaty::Color;
 pub struct Knight;
 
 impl Knight {
+    #[must_use]
     pub fn to_string(display_mode: &DisplayMode, size: PieceSize, color: Option<Color>) -> String {
         match display_mode {
             DisplayMode::DEFAULT | DisplayMode::CUSTOM => match size {

--- a/src/pieces/mod.rs
+++ b/src/pieces/mod.rs
@@ -23,6 +23,7 @@ pub enum PieceSize {
 
 impl PieceSize {
     /// Determine the appropriate piece size based on cell dimensions
+    #[must_use]
     pub fn from_dimensions(height: u16) -> Self {
         // If height is less than 3, use small (1x1)
         if height < 3 {
@@ -46,6 +47,7 @@ impl PieceSize {
 }
 
 /// Convert piece type to UTF-8 character
+#[must_use]
 pub fn role_to_utf_enum(role: &Role, color: Option<Color>) -> &'static str {
     match color {
         Some(Color::White) => match role {
@@ -70,6 +72,7 @@ pub fn role_to_utf_enum(role: &Role, color: Option<Color>) -> &'static str {
 
 /// Convert piece type to string based on display mode
 /// Note: This is used for the board grid. For multi-line designs, see individual piece modules.
+#[must_use]
 pub fn role_to_string_enum(role: Option<Role>, display_mode: &DisplayMode) -> &'static str {
     match display_mode {
         DisplayMode::DEFAULT | DisplayMode::CUSTOM => match role {

--- a/src/pieces/pawn.rs
+++ b/src/pieces/pawn.rs
@@ -5,6 +5,7 @@ use shakmaty::Color;
 pub struct Pawn;
 
 impl Pawn {
+    #[must_use]
     pub fn to_string(display_mode: &DisplayMode, size: PieceSize, color: Option<Color>) -> String {
         match display_mode {
             DisplayMode::DEFAULT | DisplayMode::CUSTOM => match size {

--- a/src/pieces/queen.rs
+++ b/src/pieces/queen.rs
@@ -5,6 +5,7 @@ use shakmaty::Color;
 pub struct Queen;
 
 impl Queen {
+    #[must_use]
     pub fn to_string(display_mode: &DisplayMode, size: PieceSize, color: Option<Color>) -> String {
         match display_mode {
             DisplayMode::DEFAULT | DisplayMode::CUSTOM => match size {

--- a/src/pieces/rook.rs
+++ b/src/pieces/rook.rs
@@ -5,6 +5,7 @@ use shakmaty::Color;
 pub struct Rook;
 
 impl Rook {
+    #[must_use]
     pub fn to_string(display_mode: &DisplayMode, size: PieceSize, color: Option<Color>) -> String {
         match display_mode {
             DisplayMode::DEFAULT | DisplayMode::CUSTOM => match size {

--- a/src/server/game_server.rs
+++ b/src/server/game_server.rs
@@ -39,11 +39,17 @@ impl GameServer {
 
     pub fn run(&self) {
         log::info!("Starting game server on 0.0.0.0:{}", NETWORK_PORT);
-        let listener = TcpListener::bind(format!("0.0.0.0:{}", NETWORK_PORT))
-            .expect("Failed to create listener");
-        listener
-            .set_nonblocking(true)
-            .expect("Failed to set listener to non-blocking");
+        let listener = match TcpListener::bind(format!("0.0.0.0:{NETWORK_PORT}")) {
+            Ok(l) => l,
+            Err(e) => {
+                log::error!("Failed to create listener: {e}");
+                return;
+            }
+        };
+        if let Err(e) = listener.set_nonblocking(true) {
+            log::error!("Failed to set listener to non-blocking: {e}");
+            return;
+        }
 
         let state = self.clients.clone();
         let stop_signal = self.stop_signal.clone();
@@ -75,22 +81,44 @@ impl GameServer {
 
                     thread::spawn(move || {
                         {
-                            let mut state_lock = state.lock().unwrap();
+                            let Ok(mut state_lock) = state.lock() else {
+                                log::error!("Failed to acquire state lock");
+                                return;
+                            };
                             // There is already one player (host who choose the color) we will need to send the color to the joining player and inform the host of the game start
                             if state_lock.len() == 1 {
-                                stream.write_all(color.as_bytes()).unwrap();
-                                let other_player = state_lock.last().unwrap();
-                                let mut other_player_stream =
-                                    other_player.stream.try_clone().unwrap();
-                                other_player_stream.write_all("s".as_bytes()).unwrap();
+                                if stream.write_all(color.as_bytes()).is_err() {
+                                    log::error!("Failed to write color to stream");
+                                    return;
+                                }
+                                let Some(other_player) = state_lock.last() else {
+                                    log::error!("No other player found");
+                                    return;
+                                };
+                                let Ok(mut other_player_stream) = other_player.stream.try_clone()
+                                else {
+                                    log::error!("Failed to clone other player stream");
+                                    return;
+                                };
+                                if other_player_stream.write_all(b"s").is_err() {
+                                    log::error!("Failed to notify other player of game start");
+                                }
                             } else if state_lock.len() >= 2 {
-                                stream.write_all("Game is already full".as_bytes()).unwrap();
+                                let _ = stream.write_all(b"Game is already full");
                                 return;
                             }
 
+                            let Ok(addr) = stream.peer_addr() else {
+                                log::error!("Failed to get peer address");
+                                return;
+                            };
+                            let Ok(stream_clone) = stream.try_clone() else {
+                                log::error!("Failed to clone stream");
+                                return;
+                            };
                             state_lock.push(Client {
-                                addr: stream.peer_addr().unwrap().to_string(),
-                                stream: stream.try_clone().unwrap(),
+                                addr: addr.to_string(),
+                                stream: stream_clone,
                             });
                         }
                         handle_client(state, stop_signal, stream);
@@ -112,7 +140,13 @@ fn handle_client(
     stop_signal: Arc<AtomicBool>,
     mut stream: TcpStream,
 ) {
-    let addr = stream.peer_addr().unwrap().to_string();
+    let addr = match stream.peer_addr() {
+        Ok(a) => a.to_string(),
+        Err(e) => {
+            log::error!("Failed to get peer address: {e}");
+            return;
+        }
+    };
     log::info!("Starting client handler for: {}", addr);
 
     // Set socket to non-blocking mode
@@ -157,18 +191,25 @@ fn handle_client(
 }
 
 fn broadcast_message(state: Arc<Mutex<Vec<Client>>>, message: String, sender_addr: &String) {
-    let state = state.lock().unwrap();
-    for client in state.iter() {
+    let Ok(state) = state.lock() else {
+        log::error!("Failed to acquire state lock for broadcast");
+        return;
+    };
+    for client in &*state {
         if &client.addr == sender_addr {
             continue;
         }
-        let mut client_stream = client.stream.try_clone().unwrap();
-        client_stream.write_all(message.as_bytes()).unwrap();
+        if let Ok(mut client_stream) = client.stream.try_clone() {
+            let _ = client_stream.write_all(message.as_bytes());
+        }
     }
 }
 
 fn remove_client(state: &Arc<Mutex<Vec<Client>>>, addr: &str) {
-    let mut state_lock = state.lock().unwrap();
+    let Ok(mut state_lock) = state.lock() else {
+        log::error!("Failed to acquire state lock for client removal");
+        return;
+    };
     if let Some(index) = state_lock.iter().position(|client| client.addr == addr) {
         state_lock.remove(index);
     }

--- a/src/skin.rs
+++ b/src/skin.rs
@@ -36,12 +36,22 @@ pub struct SkinCollection {
 }
 
 impl Skin {
+    /// Loads a skin from a JSON file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or parsed.
     pub fn load_from_file<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn std::error::Error>> {
         let content = fs::read_to_string(path)?;
         let skin: Skin = serde_json::from_str(&content)?;
         Ok(skin)
     }
 
+    /// Loads all skins from a JSON file containing a collection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or parsed.
     pub fn load_all_skins<P: AsRef<Path>>(
         path: P,
     ) -> Result<Vec<Skin>, Box<dyn std::error::Error>> {
@@ -50,11 +60,13 @@ impl Skin {
         Ok(collection.skins)
     }
 
+    #[must_use]
     pub fn get_skin_by_name(skins: &[Skin], name: &str) -> Option<Skin> {
         skins.iter().find(|s| s.name == name).cloned()
     }
 
     /// Creates a special "Default" display mode skin entry
+    #[must_use]
     pub fn default_display_mode() -> Self {
         Self {
             name: "Default".to_string(),
@@ -69,6 +81,7 @@ impl Skin {
     }
 
     /// Creates a special "ASCII" display mode skin entry
+    #[must_use]
     pub fn ascii_display_mode() -> Self {
         Self {
             name: "ASCII".to_string(),

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -94,7 +94,8 @@ pub fn play_move_sound() {
 
                 // Convert to i16 sample (truncation is intentional for audio)
                 let sample_i16 = (sample * f64::from(i16::MAX))
-                    .clamp(f64::from(i16::MIN), f64::from(i16::MAX)) as i16;
+                    .clamp(f64::from(i16::MIN), f64::from(i16::MAX))
+                    as i16;
                 samples.push(sample_i16);
             }
 
@@ -154,7 +155,8 @@ pub fn play_menu_nav_sound() {
 
                 // Convert to i16 sample (truncation is intentional for audio)
                 let sample_i16 = (sample * f64::from(i16::MAX))
-                    .clamp(f64::from(i16::MIN), f64::from(i16::MAX)) as i16;
+                    .clamp(f64::from(i16::MIN), f64::from(i16::MAX))
+                    as i16;
                 samples.push(sample_i16);
             }
 

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -57,15 +57,18 @@ pub fn play_move_sound() {
 
             // Generate a pleasant wood-like click sound
             // Using a lower fundamental frequency with harmonics for a richer sound
-            let sample_rate = 44100;
+            let sample_rate = 44100_u32;
             let duration = 0.08; // 80 milliseconds - slightly longer for better perception
             let fundamental = 200.0; // Lower frequency for a more pleasant, less harsh sound
 
-            let num_samples = (sample_rate as f64 * duration) as usize;
+            // Safe conversion: sample_rate * duration is always positive and within reasonable bounds
+            let num_samples = (f64::from(sample_rate) * duration) as usize;
             let mut samples = Vec::with_capacity(num_samples);
 
             for i in 0..num_samples {
-                let t = i as f64 / sample_rate as f64;
+                // Note: precision loss is acceptable for audio sample calculations
+                #[allow(clippy::cast_precision_loss)]
+                let t = i as f64 / f64::from(sample_rate);
 
                 // Create a more sophisticated envelope with exponential decay
                 // Quick attack, smooth decay - like a wood piece being placed
@@ -89,10 +92,10 @@ pub fn play_move_sound() {
                 // Combine harmonics with envelope
                 let sample = (fundamental_wave + harmonic2 + harmonic3) * envelope * 0.25;
 
-                // Convert to i16 sample
-                samples.push(
-                    (sample * i16::MAX as f64).clamp(i16::MIN as f64, i16::MAX as f64) as i16,
-                );
+                // Convert to i16 sample (truncation is intentional for audio)
+                let sample_i16 = (sample * f64::from(i16::MAX))
+                    .clamp(f64::from(i16::MIN), f64::from(i16::MAX)) as i16;
+                samples.push(sample_i16);
             }
 
             // Convert to a source that rodio can play
@@ -125,15 +128,18 @@ pub fn play_menu_nav_sound() {
             };
 
             // Generate a light, high-pitched tick sound for menu navigation
-            let sample_rate = 44100;
+            let sample_rate = 44100_u32;
             let duration = 0.04;
             let frequency = 600.0;
 
-            let num_samples = (sample_rate as f64 * duration) as usize;
+            // Safe conversion: sample_rate * duration is always positive and within reasonable bounds
+            let num_samples = (f64::from(sample_rate) * duration) as usize;
             let mut samples = Vec::with_capacity(num_samples);
 
             for i in 0..num_samples {
-                let t = i as f64 / sample_rate as f64;
+                // Note: precision loss is acceptable for audio sample calculations
+                #[allow(clippy::cast_precision_loss)]
+                let t = i as f64 / f64::from(sample_rate);
 
                 let envelope = if t < duration * 0.2 {
                     (t / (duration * 0.2)).powf(0.3)
@@ -146,9 +152,10 @@ pub fn play_menu_nav_sound() {
 
                 let sample = (t * frequency * 2.0 * std::f64::consts::PI).sin() * envelope * 0.3;
 
-                samples.push(
-                    (sample * i16::MAX as f64).clamp(i16::MIN as f64, i16::MAX as f64) as i16,
-                );
+                // Convert to i16 sample (truncation is intentional for audio)
+                let sample_i16 = (sample * f64::from(i16::MAX))
+                    .clamp(f64::from(i16::MIN), f64::from(i16::MAX)) as i16;
+                samples.push(sample_i16);
             }
 
             // Convert to a source that rodio can play

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,7 @@ use crate::game_logic::coord::Coord;
 use ratatui::style::Color;
 use shakmaty::Square;
 
+#[must_use]
 pub fn color_to_ratatui_enum(piece_color: Option<shakmaty::Color>) -> Color {
     match piece_color {
         Some(shakmaty::Color::Black) => Color::Black,
@@ -10,6 +11,7 @@ pub fn color_to_ratatui_enum(piece_color: Option<shakmaty::Color>) -> Color {
     }
 }
 
+#[must_use]
 pub fn flip_square_if_needed(square: Square, is_flipped: bool) -> Square {
     if is_flipped {
         Coord::from_square(square)
@@ -21,6 +23,7 @@ pub fn flip_square_if_needed(square: Square, is_flipped: bool) -> Square {
     }
 }
 
+#[must_use]
 pub fn get_square_from_coord(coord: Coord, is_flipped: bool) -> Option<Square> {
     if is_flipped {
         coord.reverse().to_square()
@@ -29,6 +32,7 @@ pub fn get_square_from_coord(coord: Coord, is_flipped: bool) -> Option<Square> {
     }
 }
 
+#[must_use]
 pub fn get_coord_from_square(square: Option<Square>, is_flipped: bool) -> Coord {
     if let Some(s) = square {
         if is_flipped {
@@ -42,35 +46,38 @@ pub fn get_coord_from_square(square: Option<Square>, is_flipped: bool) -> Coord 
 }
 
 /// Convert a character to an integer for parsing UCI moves
+#[must_use]
 pub fn get_int_from_char(c: Option<char>) -> u8 {
     match c {
-        Some('a') | Some('0') => 0,
-        Some('b') | Some('1') => 1,
-        Some('c') | Some('2') => 2,
-        Some('d') | Some('3') => 3,
-        Some('e') | Some('4') => 4,
-        Some('f') | Some('5') => 5,
-        Some('g') | Some('6') => 6,
-        Some('h') | Some('7') => 7,
+        Some('b' | '1') => 1,
+        Some('c' | '2') => 2,
+        Some('d' | '3') => 3,
+        Some('e' | '4') => 4,
+        Some('f' | '5') => 5,
+        Some('g' | '6') => 6,
+        Some('h' | '7') => 7,
         _ => 0,
     }
 }
 
+#[must_use]
 pub fn get_opposite_square(square: Option<Square>) -> Option<Square> {
     square.and_then(|s| Coord::from_square(s).reverse().to_square())
 }
 
 /// Convert position format ("4644") to UCI notation (e.g., "e4e4")
+#[must_use]
 pub fn convert_position_into_notation(position: &str) -> String {
     let chars: Vec<char> = position.chars().collect();
     if chars.len() < 4 {
         return String::new();
     }
 
-    let from_row = chars[0].to_digit(10).unwrap_or(0) as u8;
-    let from_col = chars[1].to_digit(10).unwrap_or(0) as u8;
-    let to_row = chars[2].to_digit(10).unwrap_or(0) as u8;
-    let to_col = chars[3].to_digit(10).unwrap_or(0) as u8;
+    // Safe conversion: to_digit returns values 0-9, which fits in u8
+    let from_row = chars[0].to_digit(10).unwrap_or(0).min(255) as u8;
+    let from_col = chars[1].to_digit(10).unwrap_or(0).min(255) as u8;
+    let to_row = chars[2].to_digit(10).unwrap_or(0).min(255) as u8;
+    let to_col = chars[3].to_digit(10).unwrap_or(0).min(255) as u8;
 
     // Convert from our internal format to chess notation
     // Row is inverted: row 0 = rank 8, row 7 = rank 1


### PR DESCRIPTION
# Add Clippy Linting Rules and Fix Code Quality Issues

## Description

This PR introduces strict clippy linting rules to improve code quality and safety across the entire codebase. The changes enforce better error handling practices and warn against potentially unsafe patterns.

### Clippy Rules Added

The following clippy lints have been added to `Cargo.toml`:

**Deny Level:**

- `correctness` - Prevents code that is outright wrong or useless
- `suspicious` - Prevents code that is most likely wrong or useless

**Warn Level:**

- `style` - Code that should be written in a more idiomatic way
- `complexity` - Code that can be simplified
- `perf` - Code that can be written to run faster
- `unwrap_used` - Warns on `.unwrap()` calls that could panic
- `expect_used` - Warns on `.expect()` calls that could panic
- `todo` - Warns on `todo!()` macros in code
- `dbg_macro` - Warns on `dbg!()` macros that should be removed

## How Has This Been Tested?

- [x] All existing tests pass
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo build --release` completes successfully
- [x] Manual testing of core functionality (local gameplay, bot moves, history navigation)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (error handling)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] The codebase now has stricter linting rules to maintain code quality going forward
