### PR TITLE
fix: history add scrolling when too many moves

### DIFF
--- a/src/game_logic/ui.rs
+++ b/src/game_logic/ui.rs
@@ -417,7 +417,14 @@ impl UI {
         // Determine alignment: center for all modes
         let alignment = Alignment::Center;
 
-        let history_paragraph = Paragraph::new(lines).alignment(alignment);
+        // Auto-scroll so the latest moves are visible when content exceeds the area height
+        let line_count = lines.len() as u16;
+        let visible_height = inner_area.height;
+        let vertical_offset = line_count.saturating_sub(visible_height);
+
+        let history_paragraph = Paragraph::new(lines)
+            .alignment(alignment)
+            .scroll((vertical_offset, 0));
 
         frame.render_widget(history_block.clone(), right_panel_layout[0]);
         frame.render_widget(history_paragraph, inner_area);


### PR DESCRIPTION
# Add scrolling to the history

## Description

We use the ratatui paragraph scroll for the history

Fixes #210 

## How Has This Been Tested?

Manual testing with different zooms

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
