### PR TITLE
Fixed Menu Redirect

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -693,9 +693,6 @@ impl App {
                 ));
                 self.current_popup = Some(Popups::Success);
 
-                // Immediately refetch ongoing games in the main thread
-                self.fetch_ongoing_games();
-
                 log::info!(
                     "Resignation request sent for game {} vs {}",
                     game_id,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -187,9 +187,11 @@ fn handle_popup_input(app: &mut App, key_event: KeyEvent, popup: Popups) {
                 app.error_message = None;
                 // Navigate back to an appropriate page based on current context
                 match app.current_page {
-                    Pages::Lichess | Pages::OngoingGames => {
-                        // If we're on Lichess-related pages, go back to Lichess menu
+                    Pages::Lichess => {
                         app.current_page = Pages::LichessMenu;
+                    }
+                    Pages::OngoingGames => {
+                        app.fetch_ongoing_games();
                     }
                     Pages::Multiplayer | Pages::Bot => {
                         // If we're on multiplayer or bot page, go back to home


### PR DESCRIPTION
## Description
When we resign from a game it now redirects to the Ongoing Games menu.
Fixes #190 

## How Has This Been Tested?

This was done manually by creating a game in lichess and then resigning within the Ongoing Games
tui menu.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
