### PR TITLE
  PGN Import and Visualization

### DIFF
--- a/examples/sample.pgn
+++ b/examples/sample.pgn
@@ -1,0 +1,22 @@
+[Event "Live Chess"]
+[Site "Chess.com"]
+[Date "2026.03.07"]
+[Round "?"]
+[White "Player A"]
+[Black "Player B"]
+[Result "0-1"]
+[TimeControl "600"]
+[WhiteElo "703"]
+[BlackElo "1181"]
+[Termination "Player B won by checkmate"]
+[ECO "D10"]
+[EndTime "4:40:03 GMT+0000"]
+
+1. d4 c6 2. c4 d5 3. e4 e6 4. e5 dxc4 5. Bxc4 f6 6. Nf3 c5 7. exf6 Nxf6 8. Bg5
+h6 9. Bf4 Be7 10. O-O O-O 11. Nc3 a6 12. Ne5 b5 13. Be2 Qxd4 14. Qxd4 cxd4 15.
+Nb1 Nbd7 16. Ng6 Rf7 17. Nxe7+ Rxe7 18. Bd6 Rf7 19. Nd2 Bb7 20. Rac1 Rc8 21.
+Rxc8+ Bxc8 22. Bf3 Nb6 23. Re1 Nc4 24. Ne4 Nxe4 25. Bxe4 Nxd6 26. Bg6 Rf6 27.
+Bc2 Bb7 28. Bb3 Bc8 29. g4 Rg6 30. h3 h5 31. f3 Nf7 32. Rc1 Bb7 33. a4 bxa4 34.
+Bxa4 Bxf3 35. Rc8+ Kh7 36. Bc2 hxg4 37. Bxg6+ Kxg6 38. h4 Kh5 39. Rf8 Ne5 40. b4
+Kxh4 41. Rf5 exf5 42. Kf2 g3+ 43. Kf1 g2+ 44. Kf2 Kh3 45. Kg1 d3 46. b5 d2 47.
+b6 d1=Q+ 48. Kf2 Qe2+ 49. Kg1 Qf1# 0-1

--- a/src/app.rs
+++ b/src/app.rs
@@ -99,6 +99,10 @@ pub struct App {
     pub custom_time_minutes: u32,
     /// Whether the game ended due to time running out
     pub game_ended_by_time: bool,
+    /// PGN viewer: list of games loaded from a PGN file
+    pub pgn_viewer_state: Option<Vec<crate::pgn_viewer::PgnViewer>>,
+    /// PGN viewer: which game is currently shown
+    pub pgn_viewer_game_idx: usize,
 }
 
 impl Default for App {
@@ -139,6 +143,8 @@ impl Default for App {
             clock_form_cursor: 3,    // Default: Rapid (index 3 = 15 minutes)
             custom_time_minutes: 10, // Default custom time: 10 minutes
             game_ended_by_time: false,
+            pgn_viewer_state: None,
+            pgn_viewer_game_idx: 0,
         }
     }
 }
@@ -993,6 +999,13 @@ impl App {
 
     /// Handles the tick event of the terminal.
     pub fn tick(&mut self) {
+        // Advance PGN viewer auto-play
+        if let Some(ref mut games) = self.pgn_viewer_state {
+            if let Some(viewer) = games.get_mut(self.pgn_viewer_game_idx) {
+                viewer.tick();
+            }
+        }
+
         // Update cursor blink state (used to flicker the cursor cell when a piece is selected)
         self.game.ui.update_cursor_blink();
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1256,6 +1256,13 @@ impl App {
     }
 
     pub fn check_game_end_status(&mut self) {
+        // PGN viewer drives its own game state via sync_pgn_to_board; running
+        // update_game_state here would flip it to Checkmate/Draw on the final
+        // position and open the EndScreen popup, which blocks viewer navigation.
+        if self.current_page == Pages::PgnViewer {
+            return;
+        }
+
         let previous_state = self.game.logic.game_state;
         self.game.logic.update_game_state();
         let new_state = self.game.logic.game_state;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -86,11 +86,12 @@ pub enum Pages {
     Bot,
     Credit,
     GameModeMenu,
+    PgnViewer,
 }
 impl Pages {
     #[must_use]
     pub fn variant_count() -> usize {
-        8
+        9
     }
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -111,4 +111,5 @@ pub enum Popups {
     EnterLichessToken,
     ResignConfirmation,
     MoveInputSelection,
+    LoadPgnPath,
 }

--- a/src/game_logic/ui.rs
+++ b/src/game_logic/ui.rs
@@ -69,6 +69,8 @@ pub struct UI {
     pub cursor_blink_counter: u8,
     /// The piece styles of the game
     pub available_piece_styles: Vec<PieceStyle>,
+    /// When true the cursor cell is not drawn (used by the PGN viewer, which is read-only).
+    pub hide_cursor: bool,
 }
 
 impl Default for UI {
@@ -90,6 +92,7 @@ impl Default for UI {
             cursor_blink_visible: true,
             cursor_blink_counter: 0,
             available_piece_styles: Vec::new(),
+            hide_cursor: false,
         }
     }
 }
@@ -799,7 +802,7 @@ impl UI {
             frame.render_widget(cell, square);
         }
 
-        if current_rendering_coord == self.cursor_coordinates {
+        if !self.hide_cursor && current_rendering_coord == self.cursor_coordinates {
             let cursor_color = match self.display_mode {
                 DisplayMode::CUSTOM => self.skin.cursor_color,
                 _ => Color::LightBlue,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -355,6 +355,105 @@ fn handle_page_input(app: &mut App, key_event: KeyEvent) {
         Pages::OngoingGames => handle_ongoing_games_page_events(app, key_event),
         Pages::Bot => handle_bot_page_events(app, key_event),
         Pages::Credit => handle_credit_page_events(app, key_event),
+        Pages::PgnViewer => handle_pgn_viewer_events(app, key_event),
+    }
+}
+
+/// Handles keyboard input in PGN viewer mode.
+fn handle_pgn_viewer_events(app: &mut App, key_event: KeyEvent) {
+    let game_count = app
+        .pgn_viewer_state
+        .as_ref()
+        .map(|g| g.len())
+        .unwrap_or(0);
+
+    match key_event.code {
+        // Quit viewer
+        KeyCode::Esc | KeyCode::Char('q') => {
+            app.current_page = Pages::Home;
+            app.pgn_viewer_state = None;
+            app.pgn_viewer_game_idx = 0;
+        }
+
+        // Next move
+        KeyCode::Right | KeyCode::Char('l') => {
+            if let Some(ref mut games) = app.pgn_viewer_state {
+                if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
+                    v.next();
+                }
+            }
+        }
+
+        // Previous move
+        KeyCode::Left | KeyCode::Char('h') => {
+            if let Some(ref mut games) = app.pgn_viewer_state {
+                if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
+                    v.prev();
+                }
+            }
+        }
+
+        // Go to start
+        KeyCode::Char('g') => {
+            if let Some(ref mut games) = app.pgn_viewer_state {
+                if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
+                    v.goto_start();
+                }
+            }
+        }
+
+        // Go to end
+        KeyCode::Char('G') => {
+            if let Some(ref mut games) = app.pgn_viewer_state {
+                if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
+                    v.goto_end();
+                }
+            }
+        }
+
+        // Toggle auto-play
+        KeyCode::Char(' ') => {
+            if let Some(ref mut games) = app.pgn_viewer_state {
+                if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
+                    v.auto_play = !v.auto_play;
+                    v.auto_play_tick = 0;
+                }
+            }
+        }
+
+        // Speed up
+        KeyCode::Char('+') | KeyCode::Char('=') => {
+            if let Some(ref mut games) = app.pgn_viewer_state {
+                if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
+                    v.speed_up();
+                }
+            }
+        }
+
+        // Slow down
+        KeyCode::Char('-') => {
+            if let Some(ref mut games) = app.pgn_viewer_state {
+                if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
+                    v.speed_down();
+                }
+            }
+        }
+
+        // Next game (Tab)
+        KeyCode::Tab if game_count > 1 => {
+            app.pgn_viewer_game_idx = (app.pgn_viewer_game_idx + 1) % game_count;
+        }
+
+        // Previous game (BackTab / Shift+Tab)
+        KeyCode::BackTab if game_count > 1 => {
+            if app.pgn_viewer_game_idx == 0 {
+                app.pgn_viewer_game_idx = game_count - 1;
+            } else {
+                app.pgn_viewer_game_idx -= 1;
+            }
+        }
+
+        _ => {}
     }
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -397,11 +397,12 @@ fn handle_pgn_viewer_events(app: &mut App, key_event: KeyEvent) {
     let game_count = app.pgn_viewer_state.as_ref().map(|g| g.len()).unwrap_or(0);
 
     match key_event.code {
-        // Quit viewer
+        // Quit viewer - full reset so the injected board state does not leak
+        // into the next game (position history, hidden cursor, etc.).
         KeyCode::Esc | KeyCode::Char('q') => {
-            app.current_page = Pages::Home;
             app.pgn_viewer_state = None;
             app.pgn_viewer_game_idx = 0;
+            app.reset_home();
         }
 
         // Next move
@@ -413,11 +414,16 @@ fn handle_pgn_viewer_events(app: &mut App, key_event: KeyEvent) {
             }
         }
 
-        // Previous move
+        // Previous move - or dismiss end-of-game banner when it's visible
         KeyCode::Left | KeyCode::Char('h' | 'p' | 'P') => {
             if let Some(ref mut games) = app.pgn_viewer_state {
                 if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
-                    v.prev();
+                    let is_h = matches!(key_event.code, KeyCode::Char('h' | 'H'));
+                    if is_h && v.is_at_end() && !v.end_banner_dismissed {
+                        v.end_banner_dismissed = true;
+                    } else {
+                        v.prev();
+                    }
                 }
             }
         }
@@ -448,7 +454,7 @@ fn handle_pgn_viewer_events(app: &mut App, key_event: KeyEvent) {
             if let Some(ref mut games) = app.pgn_viewer_state {
                 if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
                     v.auto_play = !v.auto_play;
-                    v.auto_play_tick = 0;
+                    v.auto_play_accum = 0.0;
                 }
             }
         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -286,6 +286,39 @@ fn handle_popup_input(app: &mut App, key_event: KeyEvent, popup: Popups) {
             }
             _ => fallback_key_handler(app, key_event),
         },
+        Popups::LoadPgnPath => match key_event.code {
+            KeyCode::Enter => {
+                app.game.ui.prompt.submit_message();
+                let path = app.game.ui.prompt.message.clone().trim().to_string();
+                if path.is_empty() {
+                    app.current_popup = None;
+                    return;
+                }
+                match crate::pgn_viewer::PgnViewer::from_file(&path) {
+                    Ok(games) => {
+                        app.pgn_viewer_state = Some(games);
+                        app.pgn_viewer_game_idx = 0;
+                        app.current_page = Pages::PgnViewer;
+                        app.current_popup = None;
+                        app.game.ui.prompt.reset();
+                    }
+                    Err(e) => {
+                        app.error_message = Some(format!("Failed to load PGN:\n{}", e));
+                        app.current_popup = Some(Popups::Error);
+                        app.game.ui.prompt.reset();
+                    }
+                }
+            }
+            KeyCode::Char(to_insert) => app.game.ui.prompt.enter_char(to_insert),
+            KeyCode::Backspace => app.game.ui.prompt.delete_char(),
+            KeyCode::Left => app.game.ui.prompt.move_cursor_left(),
+            KeyCode::Right => app.game.ui.prompt.move_cursor_right(),
+            KeyCode::Esc => {
+                app.current_popup = None;
+                app.game.ui.prompt.reset();
+            }
+            _ => fallback_key_handler(app, key_event),
+        },
         Popups::MoveInputSelection => match key_event.code {
             KeyCode::Enter => {
                 // Submit the entered move
@@ -373,7 +406,7 @@ fn handle_pgn_viewer_events(app: &mut App, key_event: KeyEvent) {
         }
 
         // Next move
-        KeyCode::Right | KeyCode::Char('l') => {
+        KeyCode::Right | KeyCode::Char('l' | 'n' | 'N') => {
             if let Some(ref mut games) = app.pgn_viewer_state {
                 if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
                     v.next();
@@ -382,13 +415,16 @@ fn handle_pgn_viewer_events(app: &mut App, key_event: KeyEvent) {
         }
 
         // Previous move
-        KeyCode::Left | KeyCode::Char('h') => {
+        KeyCode::Left | KeyCode::Char('h' | 'p' | 'P') => {
             if let Some(ref mut games) = app.pgn_viewer_state {
                 if let Some(v) = games.get_mut(app.pgn_viewer_game_idx) {
                     v.prev();
                 }
             }
         }
+
+        // Help popup
+        KeyCode::Char('?') => app.toggle_help_popup(),
 
         // Go to start
         KeyCode::Char('g') => {
@@ -993,8 +1029,8 @@ fn handle_lichess_menu_page_events(app: &mut App, key_event: KeyEvent) {
 /// Handles keyboard input on the Game Mode menu page.
 /// Supports navigation through menu items, form fields, and selection.
 fn handle_game_mode_menu_page_events(app: &mut App, key_event: KeyEvent) {
-    // Ensure cursor is valid (0-2)
-    if app.menu_cursor > 2 {
+    // Ensure cursor is valid (0-3)
+    if app.menu_cursor > 3 {
         app.menu_cursor = 0;
     }
 
@@ -1386,10 +1422,10 @@ fn handle_game_mode_menu_page_events(app: &mut App, key_event: KeyEvent) {
         // Menu navigation mode (form not active)
         match key_event.code {
             KeyCode::Up | KeyCode::Char('k') => {
-                app.menu_cursor_up(3);
+                app.menu_cursor_up(4);
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                app.menu_cursor_down(3);
+                app.menu_cursor_down(4);
             }
             KeyCode::Left | KeyCode::Char('h') => {
                 // Change game mode selection
@@ -1399,27 +1435,19 @@ fn handle_game_mode_menu_page_events(app: &mut App, key_event: KeyEvent) {
             }
             KeyCode::Right | KeyCode::Char('l') => {
                 // Change game mode selection
-                if app.menu_cursor < 2 {
+                if app.menu_cursor < 3 {
                     app.menu_cursor += 1;
                 }
             }
             KeyCode::Char(' ') | KeyCode::Enter => {
-                // Activate the form for all modes
-                app.game_mode_form_active = true;
-                app.game_mode_form_cursor = 0;
-                app.game_mode_selection = Some(game_mode);
-                // Reset form state
-                if game_mode == 0 {
-                    // Local game: reset clock time to default if needed
-                    if app.clock_form_cursor > crate::constants::TIME_CONTROL_CUSTOM_INDEX {
-                        app.clock_form_cursor = 3; // Default: Rapid
-                    }
+                if game_mode == 3 {
+                    // Load PGN: skip the form and go straight to a path prompt
+                    app.game.ui.prompt.reset();
+                    app.current_popup = Some(Popups::LoadPgnPath);
                 } else {
-                    // Activate the form for modes with configuration
                     app.game_mode_form_active = true;
-                    app.game_mode_form_cursor = 0; // Start at first form field
+                    app.game_mode_form_cursor = 0;
                     app.game_mode_selection = Some(game_mode);
-                    // Reset form state
                     app.hosting = None;
                     app.selected_color = None;
                     app.is_random_color = false;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -361,11 +361,7 @@ fn handle_page_input(app: &mut App, key_event: KeyEvent) {
 
 /// Handles keyboard input in PGN viewer mode.
 fn handle_pgn_viewer_events(app: &mut App, key_event: KeyEvent) {
-    let game_count = app
-        .pgn_viewer_state
-        .as_ref()
-        .map(|g| g.len())
-        .unwrap_or(0);
+    let game_count = app.pgn_viewer_state.as_ref().map(|g| g.len()).unwrap_or(0);
 
     match key_event.code {
         // Quit viewer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,3 +38,6 @@ pub mod lichess;
 
 // Sound effects
 pub mod sound;
+
+// PGN viewer
+pub mod pgn_viewer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,11 @@ struct Args {
     /// Update skin config with built-in default (prompts for confirmation, archives current file)
     #[arg(long)]
     update_skins: bool,
+    /// Open a PGN file or directory of .pgn files directly in the viewer.
+    /// Example: chess-tui --pgn game.pgn
+    ///          chess-tui --pgn outputs/chess/games/step-000500/
+    #[arg(short = 'p', long)]
+    pgn: Option<String>,
 }
 
 fn main() -> AppResult<()> {
@@ -301,6 +306,55 @@ fn main() -> AppResult<()> {
     // Setup logging
     if let Err(e) = logging::setup_logging(&folder_path, &app.log_level) {
         eprintln!("Failed to initialize logging: {}", e);
+    }
+
+    // Load PGN file(s) if --pgn was provided
+    if let Some(ref pgn_path) = args.pgn {
+        use chess_tui::constants::Pages;
+        use chess_tui::pgn_viewer::PgnViewer;
+        use std::path::Path;
+
+        let path = Path::new(pgn_path);
+        let load_result: Result<Vec<PgnViewer>, String> = if path.is_dir() {
+            // Load all .pgn files from the directory
+            let mut all_games: Vec<PgnViewer> = Vec::new();
+            let mut entries: Vec<_> = std::fs::read_dir(path)
+                .map_err(|e| e.to_string())?
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.path()
+                        .extension()
+                        .map(|x| x == "pgn")
+                        .unwrap_or(false)
+                })
+                .collect();
+            entries.sort_by_key(|e| e.path());
+            for entry in entries {
+                match PgnViewer::from_file(entry.path().to_str().unwrap_or("")) {
+                    Ok(mut games) => all_games.append(&mut games),
+                    Err(e) => eprintln!("Skipping {:?}: {}", entry.path(), e),
+                }
+            }
+            if all_games.is_empty() {
+                Err(format!("No valid .pgn files found in '{}'", pgn_path))
+            } else {
+                Ok(all_games)
+            }
+        } else {
+            PgnViewer::from_file(pgn_path)
+        };
+
+        match load_result {
+            Ok(games) => {
+                app.pgn_viewer_state = Some(games);
+                app.pgn_viewer_game_idx = 0;
+                app.current_page = Pages::PgnViewer;
+            }
+            Err(e) => {
+                eprintln!("Failed to load PGN '{}': {}", pgn_path, e);
+                std::process::exit(1);
+            }
+        }
     }
 
     // Initialize the terminal user interface.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,12 @@ extern crate chess_tui;
 
 use chess_tui::app::{App, AppResult};
 use chess_tui::config::Config;
-use chess_tui::constants::{config_dir, DisplayMode};
+use chess_tui::constants::{config_dir, DisplayMode, Pages};
 use chess_tui::event::{Event, EventHandler};
 use chess_tui::game_logic::opponent::wait_for_game_start;
 use chess_tui::handler::{handle_key_events, handle_mouse_events};
 use chess_tui::logging;
+use chess_tui::pgn_viewer::PgnViewer;
 use chess_tui::skin::{PieceStyle, Skin};
 use chess_tui::ui::tui::Tui;
 use clap::Parser;
@@ -310,10 +311,6 @@ fn main() -> AppResult<()> {
 
     // Load PGN file(s) if --pgn was provided
     if let Some(ref pgn_path) = args.pgn {
-        use chess_tui::constants::Pages;
-        use chess_tui::pgn_viewer::PgnViewer;
-        use std::path::Path;
-
         let path = Path::new(pgn_path);
         let load_result: Result<Vec<PgnViewer>, String> = if path.is_dir() {
             // Load all .pgn files from the directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,12 +321,7 @@ fn main() -> AppResult<()> {
             let mut entries: Vec<_> = std::fs::read_dir(path)
                 .map_err(|e| e.to_string())?
                 .filter_map(|e| e.ok())
-                .filter(|e| {
-                    e.path()
-                        .extension()
-                        .map(|x| x == "pgn")
-                        .unwrap_or(false)
-                })
+                .filter(|e| e.path().extension().map(|x| x == "pgn").unwrap_or(false))
                 .collect();
             entries.sort_by_key(|e| e.path());
             for entry in entries {
@@ -624,6 +619,7 @@ mod tests {
             no_sound: false,
             skin: None,
             update_skins: false,
+            pgn: None,
         };
 
         let config_dir = config_dir().unwrap();

--- a/src/pgn_viewer.rs
+++ b/src/pgn_viewer.rs
@@ -30,6 +30,8 @@ pub struct PgnViewer {
     pub white: String,
     pub black: String,
     pub result: String,
+    /// Termination reason (e.g. "Normal", "Time forfeit", "Player A won by checkmate")
+    pub termination: String,
 }
 
 impl PgnViewer {
@@ -92,6 +94,20 @@ impl PgnViewer {
 
     pub fn total_plies(&self) -> usize {
         self.moves.len()
+    }
+
+    pub fn is_at_end(&self) -> bool {
+        !self.moves.is_empty() && self.current_ply == self.moves.len()
+    }
+
+    /// Human-readable result string for display (e.g. "White won", "Draw").
+    pub fn result_summary(&self) -> String {
+        match self.result.as_str() {
+            "1-0" => format!("{} (White) won", self.white),
+            "0-1" => format!("{} (Black) won", self.black),
+            "1/2-1/2" => "Draw".to_string(),
+            _ => self.result.clone(),
+        }
     }
 
     /// Called every app tick — advances ply when auto-play is on.
@@ -158,6 +174,7 @@ fn parse_single_game(pgn: &str) -> Result<PgnViewer, String> {
     let mut white = String::from("?");
     let mut black = String::from("?");
     let mut result = String::from("*");
+    let mut termination = String::new();
 
     for line in pgn.lines() {
         let t = line.trim();
@@ -165,14 +182,17 @@ fn parse_single_game(pgn: &str) -> Result<PgnViewer, String> {
             continue;
         }
         if let Some(val) = extract_header_value(t) {
-            if t.to_lowercase().starts_with("[event") {
+            let lower = t.to_lowercase();
+            if lower.starts_with("[event") {
                 title = val;
-            } else if t.to_lowercase().starts_with("[white") {
+            } else if lower.starts_with("[white ") || lower.starts_with("[white\"") {
                 white = val;
-            } else if t.to_lowercase().starts_with("[black") {
+            } else if lower.starts_with("[black ") || lower.starts_with("[black\"") {
                 black = val;
-            } else if t.to_lowercase().starts_with("[result") {
+            } else if lower.starts_with("[result") {
                 result = val;
+            } else if lower.starts_with("[termination") {
+                termination = val;
             }
         }
     }
@@ -237,6 +257,7 @@ fn parse_single_game(pgn: &str) -> Result<PgnViewer, String> {
         white,
         black,
         result,
+        termination,
     })
 }
 
@@ -329,4 +350,41 @@ fn extract_san_tokens(movetext: &str) -> Vec<String> {
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHECKMATE_PGN: &str = r#"[Event "Live"]
+[White "A"]
+[Black "B"]
+[Result "0-1"]
+[Termination "B won by checkmate"]
+
+1. e4 e5 2. Qh5 Nc6 3. Bc4 Nf6 4. Qxf7# 0-1
+"#;
+
+    #[test]
+    fn parses_headers_and_termination() {
+        let games = PgnViewer::from_pgn_str(CHECKMATE_PGN).expect("parse PGN");
+        let v = &games[0];
+        assert_eq!(v.white, "A");
+        assert_eq!(v.black, "B");
+        assert_eq!(v.result, "0-1");
+        assert_eq!(v.termination, "B won by checkmate");
+        assert_eq!(v.result_summary(), "B (Black) won");
+    }
+
+    #[test]
+    fn navigates_back_from_final_position() {
+        let mut games = PgnViewer::from_pgn_str(CHECKMATE_PGN).expect("parse PGN");
+        let v = &mut games[0];
+        v.goto_end();
+        assert!(v.is_at_end());
+        let end_ply = v.current_ply;
+        v.prev();
+        assert_eq!(v.current_ply, end_ply - 1);
+        assert!(!v.is_at_end());
+    }
 }

--- a/src/pgn_viewer.rs
+++ b/src/pgn_viewer.rs
@@ -6,7 +6,6 @@
 
 use shakmaty::san::San;
 use shakmaty::{Chess, Move, Position};
-use std::str::FromStr;
 
 // Auto-play tick speeds (event loop fires ~4 ticks/sec)
 pub const SPEED_FAST: u64 = 1;
@@ -36,8 +35,8 @@ pub struct PgnViewer {
 impl PgnViewer {
     /// Load all games from a PGN file.
     pub fn from_file(path: &str) -> Result<Vec<Self>, String> {
-        let content = std::fs::read_to_string(path)
-            .map_err(|e| format!("Cannot read '{}': {}", path, e))?;
+        let content =
+            std::fs::read_to_string(path).map_err(|e| format!("Cannot read '{}': {}", path, e))?;
         Self::from_pgn_str(&content)
     }
 
@@ -286,11 +285,7 @@ fn extract_san_tokens(movetext: &str) -> Vec<String> {
                     if depth == 0 {
                         if let Some(s) = open_idx {
                             // Convert char indices to byte indices
-                            let byte_s = text
-                                .char_indices()
-                                .nth(s)
-                                .map(|(i, _)| i)
-                                .unwrap_or(0);
+                            let byte_s = text.char_indices().nth(s).map(|(i, _)| i).unwrap_or(0);
                             let byte_e = text
                                 .char_indices()
                                 .nth(ci)

--- a/src/pgn_viewer.rs
+++ b/src/pgn_viewer.rs
@@ -1,0 +1,338 @@
+//! PGN viewer state — parses a PGN file into a sequence of board positions
+//! and provides navigation + auto-play controls.
+//!
+//! Supports multi-game PGN files (e.g. multiple training games saved by watch.py).
+//! Games are stored as `Vec<PgnViewer>` and the caller cycles between them.
+
+use shakmaty::san::San;
+use shakmaty::{Chess, Move, Position};
+use std::str::FromStr;
+
+// Auto-play tick speeds (event loop fires ~4 ticks/sec)
+pub const SPEED_FAST: u64 = 1;
+pub const SPEED_NORMAL: u64 = 4;
+pub const SPEED_SLOW: u64 = 8;
+
+pub struct PgnViewer {
+    /// positions[0] = starting position, positions[i] = position after moves[i-1]
+    pub positions: Vec<Chess>,
+    /// shakmaty Move objects — for board highlighting
+    pub moves: Vec<Move>,
+    /// SAN strings — for display in the history panel
+    pub sans: Vec<String>,
+    /// Which ply is currently shown (0 = start)
+    pub current_ply: usize,
+    /// Auto-play state
+    pub auto_play: bool,
+    pub auto_play_speed: u64,
+    pub auto_play_tick: u64,
+    /// Metadata from PGN headers
+    pub title: String,
+    pub white: String,
+    pub black: String,
+    pub result: String,
+}
+
+impl PgnViewer {
+    /// Load all games from a PGN file.
+    pub fn from_file(path: &str) -> Result<Vec<Self>, String> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("Cannot read '{}': {}", path, e))?;
+        Self::from_pgn_str(&content)
+    }
+
+    /// Parse a PGN string that may contain one or more games.
+    pub fn from_pgn_str(pgn: &str) -> Result<Vec<Self>, String> {
+        let mut viewers = Vec::new();
+        for game_text in split_pgn_games(pgn) {
+            match parse_single_game(&game_text) {
+                Ok(v) => viewers.push(v),
+                Err(_) => {} // skip unparseable games silently
+            }
+        }
+        if viewers.is_empty() {
+            Err("No valid games found in PGN".to_string())
+        } else {
+            Ok(viewers)
+        }
+    }
+
+    // ── Navigation ──────────────────────────────────────────────────────────
+
+    pub fn current_position(&self) -> &Chess {
+        &self.positions[self.current_ply]
+    }
+
+    /// The move that led to `current_ply` (used for board highlighting).
+    pub fn last_move(&self) -> Option<&Move> {
+        if self.current_ply > 0 {
+            self.moves.get(self.current_ply - 1)
+        } else {
+            None
+        }
+    }
+
+    pub fn next(&mut self) {
+        if self.current_ply < self.moves.len() {
+            self.current_ply += 1;
+        }
+    }
+
+    pub fn prev(&mut self) {
+        if self.current_ply > 0 {
+            self.current_ply -= 1;
+        }
+    }
+
+    pub fn goto_start(&mut self) {
+        self.current_ply = 0;
+    }
+
+    pub fn goto_end(&mut self) {
+        self.current_ply = self.moves.len();
+    }
+
+    pub fn total_plies(&self) -> usize {
+        self.moves.len()
+    }
+
+    /// Called every app tick — advances ply when auto-play is on.
+    pub fn tick(&mut self) {
+        if !self.auto_play {
+            return;
+        }
+        self.auto_play_tick += 1;
+        if self.auto_play_tick >= self.auto_play_speed {
+            self.auto_play_tick = 0;
+            if self.current_ply < self.moves.len() {
+                self.current_ply += 1;
+            } else {
+                self.auto_play = false; // stop at end
+            }
+        }
+    }
+
+    pub fn speed_up(&mut self) {
+        self.auto_play_speed = self.auto_play_speed.saturating_sub(1).max(SPEED_FAST);
+    }
+
+    pub fn speed_down(&mut self) {
+        self.auto_play_speed = (self.auto_play_speed + 1).min(16);
+    }
+}
+
+// ── PGN parsing ──────────────────────────────────────────────────────────────
+
+/// Split a multi-game PGN string into individual game strings.
+/// A new game starts when we see a header line (`[...`) after movetext.
+fn split_pgn_games(pgn: &str) -> Vec<String> {
+    let mut games: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut has_movetext = false;
+
+    for line in pgn.lines() {
+        let trimmed = line.trim();
+        // New game starts when a header arrives after we've seen movetext
+        if trimmed.starts_with('[') && has_movetext {
+            if !current.trim().is_empty() {
+                games.push(std::mem::take(&mut current));
+            }
+            has_movetext = false;
+        }
+        if !trimmed.is_empty() && !trimmed.starts_with('[') {
+            has_movetext = true;
+        }
+        current.push_str(line);
+        current.push('\n');
+    }
+    if !current.trim().is_empty() {
+        games.push(current);
+    }
+    if games.is_empty() && !pgn.trim().is_empty() {
+        games.push(pgn.to_string());
+    }
+    games
+}
+
+fn parse_single_game(pgn: &str) -> Result<PgnViewer, String> {
+    // Extract header values
+    let mut title = String::from("?");
+    let mut white = String::from("?");
+    let mut black = String::from("?");
+    let mut result = String::from("*");
+
+    for line in pgn.lines() {
+        let t = line.trim();
+        if !t.starts_with('[') {
+            continue;
+        }
+        if let Some(val) = extract_header_value(t) {
+            if t.to_lowercase().starts_with("[event") {
+                title = val;
+            } else if t.to_lowercase().starts_with("[white") {
+                white = val;
+            } else if t.to_lowercase().starts_with("[black") {
+                black = val;
+            } else if t.to_lowercase().starts_with("[result") {
+                result = val;
+            }
+        }
+    }
+
+    // Build movetext from non-header lines
+    let mut movetext = String::new();
+    let mut past_headers = false;
+    for line in pgn.lines() {
+        let t = line.trim();
+        if !t.starts_with('[') {
+            past_headers = true;
+        }
+        if past_headers {
+            movetext.push_str(line);
+            movetext.push(' ');
+        }
+    }
+
+    // Parse SAN tokens from movetext
+    let san_strings = extract_san_tokens(&movetext);
+
+    // Apply moves to build position chain
+    let mut positions: Vec<Chess> = vec![Chess::default()];
+    let mut moves: Vec<Move> = Vec::new();
+    let mut sans: Vec<String> = Vec::new();
+    let mut pos = Chess::default();
+
+    for san_str in &san_strings {
+        // Strip check/checkmate annotations — shakmaty's San parser handles them
+        // but being explicit avoids issues with non-standard suffixes
+        let clean: &str = san_str.trim_end_matches(|c: char| c == '+' || c == '#');
+        match clean.parse::<San>() {
+            Ok(san) => match san.to_move(&pos) {
+                Ok(mv) => match pos.clone().play(&mv) {
+                    Ok(new_pos) => {
+                        moves.push(mv);
+                        sans.push(san_str.clone());
+                        pos = new_pos;
+                        positions.push(pos.clone());
+                    }
+                    Err(_) => break,
+                },
+                Err(_) => break,
+            },
+            Err(_) => break,
+        }
+    }
+
+    if moves.is_empty() {
+        return Err(format!("No moves parsed from game '{}'", title));
+    }
+
+    Ok(PgnViewer {
+        positions,
+        moves,
+        sans,
+        current_ply: 0,
+        auto_play: false,
+        auto_play_speed: SPEED_NORMAL,
+        auto_play_tick: 0,
+        title,
+        white,
+        black,
+        result,
+    })
+}
+
+/// Extract a header value from a PGN tag like `[White "Magnus Carlsen"]`.
+fn extract_header_value(line: &str) -> Option<String> {
+    let start = line.find('"')?;
+    let end = line.rfind('"')?;
+    if end > start {
+        Some(line[start + 1..end].to_string())
+    } else {
+        None
+    }
+}
+
+/// Strip comments, variations and move numbers from movetext, return SAN tokens.
+fn extract_san_tokens(movetext: &str) -> Vec<String> {
+    let mut text = movetext.to_string();
+
+    // Remove block comments {…}  (may span multiple words)
+    loop {
+        match (text.find('{'), text.find('}')) {
+            (Some(s), Some(e)) if e > s => {
+                text.replace_range(s..=e, " ");
+            }
+            _ => break,
+        }
+    }
+
+    // Remove variations (…) — handle nesting
+    loop {
+        let mut found = false;
+        let chars: Vec<char> = text.chars().collect();
+        let mut depth = 0usize;
+        let mut open_idx: Option<usize> = None;
+        for (ci, &c) in chars.iter().enumerate() {
+            match c {
+                '(' => {
+                    if depth == 0 {
+                        open_idx = Some(ci);
+                    }
+                    depth += 1;
+                }
+                ')' if depth > 0 => {
+                    depth -= 1;
+                    if depth == 0 {
+                        if let Some(s) = open_idx {
+                            // Convert char indices to byte indices
+                            let byte_s = text
+                                .char_indices()
+                                .nth(s)
+                                .map(|(i, _)| i)
+                                .unwrap_or(0);
+                            let byte_e = text
+                                .char_indices()
+                                .nth(ci)
+                                .map(|(i, _)| i + 1)
+                                .unwrap_or(text.len());
+                            text.replace_range(byte_s..byte_e, " ");
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if !found {
+            break;
+        }
+    }
+
+    let mut result = Vec::new();
+    for token in text.split_whitespace() {
+        // Move numbers: "1.", "2.", "1...", "10.", etc.
+        let is_move_number = token
+            .trim_end_matches('.')
+            .chars()
+            .all(|c| c.is_ascii_digit());
+        if is_move_number {
+            continue;
+        }
+        // NAG annotations: $1, $2, …
+        if token.starts_with('$') {
+            continue;
+        }
+        // Result tokens
+        if matches!(token, "1-0" | "0-1" | "1/2-1/2" | "*") {
+            continue;
+        }
+        // Strip trailing annotation glyphs (!, ?, !?, ?!, !!, ??)
+        let clean = token.trim_end_matches(|c: char| matches!(c, '!' | '?'));
+        if !clean.is_empty() {
+            result.push(clean.to_string());
+        }
+    }
+    result
+}

--- a/src/pgn_viewer.rs
+++ b/src/pgn_viewer.rs
@@ -44,9 +44,8 @@ impl PgnViewer {
     pub fn from_pgn_str(pgn: &str) -> Result<Vec<Self>, String> {
         let mut viewers = Vec::new();
         for game_text in split_pgn_games(pgn) {
-            match parse_single_game(&game_text) {
-                Ok(v) => viewers.push(v),
-                Err(_) => {} // skip unparseable games silently
+            if let Ok(v) = parse_single_game(&game_text) {
+                viewers.push(v);
             }
         }
         if viewers.is_empty() {
@@ -204,7 +203,7 @@ fn parse_single_game(pgn: &str) -> Result<PgnViewer, String> {
     for san_str in &san_strings {
         // Strip check/checkmate annotations — shakmaty's San parser handles them
         // but being explicit avoids issues with non-standard suffixes
-        let clean: &str = san_str.trim_end_matches(|c: char| c == '+' || c == '#');
+        let clean: &str = san_str.trim_end_matches(['+', '#']);
         match clean.parse::<San>() {
             Ok(san) => match san.to_move(&pos) {
                 Ok(mv) => match pos.clone().play(&mv) {
@@ -324,7 +323,7 @@ fn extract_san_tokens(movetext: &str) -> Vec<String> {
             continue;
         }
         // Strip trailing annotation glyphs (!, ?, !?, ?!, !!, ??)
-        let clean = token.trim_end_matches(|c: char| matches!(c, '!' | '?'));
+        let clean = token.trim_end_matches(['!', '?']);
         if !clean.is_empty() {
             result.push(clean.to_string());
         }

--- a/src/pgn_viewer.rs
+++ b/src/pgn_viewer.rs
@@ -1,4 +1,4 @@
-//! PGN viewer state — parses a PGN file into a sequence of board positions
+//! PGN viewer state - parses a PGN file into a sequence of board positions
 //! and provides navigation + auto-play controls.
 //!
 //! Supports multi-game PGN files (e.g. multiple training games saved by watch.py).
@@ -7,24 +7,37 @@
 use shakmaty::san::San;
 use shakmaty::{Chess, Move, Position};
 
-// Auto-play tick speeds (event loop fires ~4 ticks/sec)
-pub const SPEED_FAST: u64 = 1;
-pub const SPEED_NORMAL: u64 = 4;
-pub const SPEED_SLOW: u64 = 8;
+/// Auto-play rate multipliers (1x ≈ one move per second).
+///
+/// The event loop ticks every 250ms, so at each tick we advance the
+/// accumulator by `rate * 0.25`; when it reaches 1.0 the next ply plays.
+pub const SPEEDS: &[(f32, &str)] = &[
+    (0.5, "0.5x"),
+    (1.0, "1x"),
+    (1.5, "1.5x"),
+    (2.0, "2x"),
+    (2.5, "2.5x"),
+    (3.0, "3x"),
+    (4.0, "4x"),
+];
+pub const DEFAULT_SPEED_IDX: usize = 1; // 1x
 
 pub struct PgnViewer {
     /// positions[0] = starting position, positions[i] = position after moves[i-1]
     pub positions: Vec<Chess>,
-    /// shakmaty Move objects — for board highlighting
+    /// shakmaty Move objects - for board highlighting
     pub moves: Vec<Move>,
-    /// SAN strings — for display in the history panel
+    /// SAN strings - for display in the history panel
     pub sans: Vec<String>,
     /// Which ply is currently shown (0 = start)
     pub current_ply: usize,
     /// Auto-play state
     pub auto_play: bool,
-    pub auto_play_speed: u64,
-    pub auto_play_tick: u64,
+    pub speed_idx: usize,
+    pub auto_play_accum: f32,
+    /// Set to true when the user presses `h` on the end-of-game banner.
+    /// Reset when the viewer moves off the final ply.
+    pub end_banner_dismissed: bool,
     /// Metadata from PGN headers
     pub title: String,
     pub white: String,
@@ -81,11 +94,13 @@ impl PgnViewer {
     pub fn prev(&mut self) {
         if self.current_ply > 0 {
             self.current_ply -= 1;
+            self.end_banner_dismissed = false;
         }
     }
 
     pub fn goto_start(&mut self) {
         self.current_ply = 0;
+        self.end_banner_dismissed = false;
     }
 
     pub fn goto_end(&mut self) {
@@ -110,28 +125,39 @@ impl PgnViewer {
         }
     }
 
-    /// Called every app tick — advances ply when auto-play is on.
+    /// Called every app tick (250ms) - advances ply when auto-play is on.
     pub fn tick(&mut self) {
         if !self.auto_play {
             return;
         }
-        self.auto_play_tick += 1;
-        if self.auto_play_tick >= self.auto_play_speed {
-            self.auto_play_tick = 0;
+        let rate = SPEEDS[self.speed_idx].0;
+        self.auto_play_accum += rate * 0.25;
+        while self.auto_play_accum >= 1.0 {
+            self.auto_play_accum -= 1.0;
             if self.current_ply < self.moves.len() {
                 self.current_ply += 1;
             } else {
-                self.auto_play = false; // stop at end
+                self.auto_play = false;
+                self.auto_play_accum = 0.0;
+                break;
             }
         }
     }
 
+    pub fn speed_label(&self) -> &'static str {
+        SPEEDS[self.speed_idx].1
+    }
+
     pub fn speed_up(&mut self) {
-        self.auto_play_speed = self.auto_play_speed.saturating_sub(1).max(SPEED_FAST);
+        if self.speed_idx + 1 < SPEEDS.len() {
+            self.speed_idx += 1;
+        }
     }
 
     pub fn speed_down(&mut self) {
-        self.auto_play_speed = (self.auto_play_speed + 1).min(16);
+        if self.speed_idx > 0 {
+            self.speed_idx -= 1;
+        }
     }
 }
 
@@ -221,7 +247,7 @@ fn parse_single_game(pgn: &str) -> Result<PgnViewer, String> {
     let mut pos = Chess::default();
 
     for san_str in &san_strings {
-        // Strip check/checkmate annotations — shakmaty's San parser handles them
+        // Strip check/checkmate annotations - shakmaty's San parser handles them
         // but being explicit avoids issues with non-standard suffixes
         let clean: &str = san_str.trim_end_matches(['+', '#']);
         match clean.parse::<San>() {
@@ -251,8 +277,9 @@ fn parse_single_game(pgn: &str) -> Result<PgnViewer, String> {
         sans,
         current_ply: 0,
         auto_play: false,
-        auto_play_speed: SPEED_NORMAL,
-        auto_play_tick: 0,
+        speed_idx: DEFAULT_SPEED_IDX,
+        auto_play_accum: 0.0,
+        end_banner_dismissed: false,
         title,
         white,
         black,
@@ -286,7 +313,7 @@ fn extract_san_tokens(movetext: &str) -> Vec<String> {
         }
     }
 
-    // Remove variations (…) — handle nesting
+    // Remove variations (…) - handle nesting
     loop {
         let mut found = false;
         let chars: Vec<char> = text.chars().collect();
@@ -386,5 +413,32 @@ mod tests {
         v.prev();
         assert_eq!(v.current_ply, end_ply - 1);
         assert!(!v.is_at_end());
+    }
+
+    #[test]
+    fn speed_is_clamped_at_bounds() {
+        let mut games = PgnViewer::from_pgn_str(CHECKMATE_PGN).expect("parse PGN");
+        let v = &mut games[0];
+        assert_eq!(v.speed_label(), "1x");
+        for _ in 0..20 {
+            v.speed_up();
+        }
+        assert_eq!(v.speed_idx, SPEEDS.len() - 1);
+        assert_eq!(v.speed_label(), "4x");
+        for _ in 0..20 {
+            v.speed_down();
+        }
+        assert_eq!(v.speed_idx, 0);
+        assert_eq!(v.speed_label(), "0.5x");
+    }
+
+    #[test]
+    fn prev_clears_end_banner_dismissal() {
+        let mut games = PgnViewer::from_pgn_str(CHECKMATE_PGN).expect("parse PGN");
+        let v = &mut games[0];
+        v.goto_end();
+        v.end_banner_dismissed = true;
+        v.prev();
+        assert!(!v.end_banner_dismissed);
     }
 }

--- a/src/ui/game_mode_menu.rs
+++ b/src/ui/game_mode_menu.rs
@@ -290,7 +290,7 @@ pub fn render_game_mode_menu(frame: &mut Frame, app: &App) {
     let left_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(12), // Menu
+            Constraint::Length(15), // Menu (4 items × 3 rows + borders)
             Constraint::Min(10),    // Form
         ])
         .split(content_chunks[0]);
@@ -318,6 +318,7 @@ pub fn render_game_mode_menu(frame: &mut Frame, app: &App) {
         ),
         ("Multiplayer", "Play with friends over network"),
         ("Play Bot", "Challenge a chess engine"),
+        ("Load PGN", "Open a .pgn file and step through the game"),
     ];
 
     let mut menu_lines = vec![Line::from("")];
@@ -605,6 +606,40 @@ fn render_details_panel(frame: &mut Frame, app: &App, area: Rect, game_mode: u8)
                 "  https://thomas-mauran.github.io/chess-tui/docs/intro",
             ));
         }
+        3 => {
+            // Load PGN details
+            info_lines.push(Line::from(vec![Span::styled(
+                "Load PGN",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )]));
+            info_lines.push(Line::from(""));
+            info_lines.push(Line::from("Open a PGN file and step through the"));
+            info_lines.push(Line::from("game move by move, with auto-play and"));
+            info_lines.push(Line::from("multi-game navigation."));
+            info_lines.push(Line::from(""));
+            info_lines.push(Line::from(vec![Span::styled(
+                "Usage:",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )]));
+            info_lines.push(Line::from("  Press Enter, then paste the"));
+            info_lines.push(Line::from("  absolute path to a .pgn file."));
+            info_lines.push(Line::from(""));
+            info_lines.push(Line::from(vec![Span::styled(
+                "Controls in viewer:",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )]));
+            info_lines.push(Line::from("  ← / P: Previous move"));
+            info_lines.push(Line::from("  → / N: Next move"));
+            info_lines.push(Line::from("  Space: Toggle auto-play"));
+            info_lines.push(Line::from("  g / G: Jump to start / end"));
+            info_lines.push(Line::from("  Tab:   Cycle games (multi-game PGN)"));
+        }
         _ => {}
     }
 
@@ -626,14 +661,17 @@ fn render_game_mode_form(frame: &mut Frame, app: &App, area: Rect, game_mode: u8
 
     // Form content area
     let form_area = area;
+    let form_title = if game_mode == 3 {
+        "Press Enter to open a PGN file"
+    } else if is_active {
+        "Configuration"
+    } else {
+        "Configuration (Press Enter to activate)"
+    };
     let form_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .title(if is_active {
-            "Configuration"
-        } else {
-            "Configuration (Press Enter to activate)"
-        });
+        .title(form_title);
     let inner_form_area = form_block.inner(form_area);
     frame.render_widget(form_block, form_area);
 

--- a/src/ui/main_ui.rs
+++ b/src/ui/main_ui.rs
@@ -22,8 +22,8 @@ use super::lichess_menu::render_lichess_menu;
 use super::ongoing_games::render_ongoing_games;
 use super::pgn_viewer_ui::render_pgn_viewer;
 use super::popups::{
-    render_enter_multiplayer_ip, render_move_input_popup, render_multiplayer_selection_popup,
-    render_wait_for_other_player,
+    render_enter_multiplayer_ip, render_load_pgn_popup, render_move_input_popup,
+    render_multiplayer_selection_popup, render_wait_for_other_player,
 };
 use crate::{
     app::App,
@@ -143,7 +143,6 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
     // PGN viewer
     else if app.current_page == Pages::PgnViewer {
         render_pgn_viewer(frame, app);
-        return; // skip popup rendering while viewing PGN
     }
     // Render menu
     else {
@@ -192,6 +191,9 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
         }
         Some(Popups::EnterGameCode) => {
             render_enter_game_code_popup(frame, &app.game.ui.prompt);
+        }
+        Some(Popups::LoadPgnPath) => {
+            render_load_pgn_popup(frame, &app.game.ui.prompt);
         }
         Some(Popups::EnterLichessToken) => {
             render_enter_lichess_token_popup(frame, &app.game.ui.prompt);

--- a/src/ui/main_ui.rs
+++ b/src/ui/main_ui.rs
@@ -20,6 +20,7 @@ use crate::{
 
 use super::lichess_menu::render_lichess_menu;
 use super::ongoing_games::render_ongoing_games;
+use super::pgn_viewer_ui::render_pgn_viewer;
 use super::popups::{
     render_enter_multiplayer_ip, render_move_input_popup, render_multiplayer_selection_popup,
     render_wait_for_other_player,
@@ -141,6 +142,11 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
     // Ongoing games list
     else if app.current_page == Pages::OngoingGames {
         render_ongoing_games(frame, app);
+    }
+    // PGN viewer
+    else if app.current_page == Pages::PgnViewer {
+        render_pgn_viewer(frame, app);
+        return; // skip popup rendering while viewing PGN
     }
     // Render menu
     else {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@ pub mod game_mode_menu;
 pub mod lichess_menu;
 pub mod main_ui;
 pub mod ongoing_games;
+pub mod pgn_viewer_ui;
 pub mod popups;
 pub mod prompt;
 pub mod tui;

--- a/src/ui/pgn_viewer_ui.rs
+++ b/src/ui/pgn_viewer_ui.rs
@@ -1,10 +1,9 @@
-//! PGN viewer UI — renders the chess board + move history for a saved game.
+//! PGN viewer UI - renders the chess board + move history for a saved game.
 //!
 //! Re-uses the existing `render_game_ui` layout by syncing the PgnViewer's current
 //! position into `app.game.logic.game_board` before rendering.
 
 use crate::app::App;
-use crate::game_logic::coord::Coord;
 use crate::game_logic::game::GameState;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -37,8 +36,8 @@ pub fn sync_pgn_to_board(app: &mut App) {
     app.game.logic.game_board.history_position_index = None;
     app.game.ui.selected_square = None;
     app.game.logic.game_state = GameState::Playing;
-    // Hide the square cursor — viewer is read-only, nothing to select.
-    app.game.ui.cursor_coordinates = Coord::undefined();
+    // Hide the square cursor - viewer is read-only, nothing to select.
+    app.game.ui.hide_cursor = true;
     // Set player_turn so history panel colouring is correct
     app.game.logic.player_turn = if current_ply % 2 == 0 {
         shakmaty::Color::White
@@ -80,7 +79,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         .as_ref()
         .and_then(|v| v.get(app.pgn_viewer_game_idx));
 
-    let (current_ply, total_plies, auto_play, speed, title, white, black, result, game_count) =
+    let (current_ply, total_plies, auto_play, speed_label, title, white, black, result, game_count) =
         if let Some(v) = viewer_opt {
             let count = app
                 .pgn_viewer_state
@@ -91,7 +90,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 v.current_ply,
                 v.total_plies(),
                 v.auto_play,
-                v.auto_play_speed,
+                v.speed_label(),
                 v.title.as_str(),
                 v.white.as_str(),
                 v.black.as_str(),
@@ -113,11 +112,6 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     let play_label = if auto_play { "Pause" } else { "Play" };
-    let speed_str = match speed {
-        1 => "Fast",
-        2..=4 => "Normal",
-        _ => "Slow",
-    };
 
     let mut nav_spans = vec![
         Span::styled("←/→", Style::default().fg(Color::Cyan)),
@@ -127,7 +121,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled("Space", Style::default().fg(Color::Cyan)),
         Span::raw(format!(" {}  ", play_label)),
         Span::styled("+/-", Style::default().fg(Color::Cyan)),
-        Span::raw(format!(" Speed:{speed_str}  ")),
+        Span::raw(format!(" Speed:{speed_label}  ")),
         Span::styled("g/G", Style::default().fg(Color::Cyan)),
         Span::raw(" Start/End  "),
     ];
@@ -206,7 +200,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 /// When the viewer sits on the final position, overlay a small banner with
-/// the final result and termination reason. Non-modal — navigation keys
+/// the final result and termination reason. Non-modal - navigation keys
 /// continue to work and the banner disappears as soon as the user steps back.
 fn render_end_banner(frame: &mut Frame, app: &App, board_area: Rect) {
     let Some(viewer) = app
@@ -217,7 +211,7 @@ fn render_end_banner(frame: &mut Frame, app: &App, board_area: Rect) {
         return;
     };
 
-    if !viewer.is_at_end() {
+    if !viewer.is_at_end() || viewer.end_banner_dismissed {
         return;
     }
 
@@ -254,7 +248,7 @@ fn render_end_banner(frame: &mut Frame, app: &App, board_area: Rect) {
     lines.extend([
         Line::from(""),
         Line::from(Span::styled(
-            "← / P to step back",
+            "h: hide  ·  ← / P: step back",
             Style::default().fg(Color::DarkGray),
         ))
         .alignment(Alignment::Center),

--- a/src/ui/pgn_viewer_ui.rs
+++ b/src/ui/pgn_viewer_ui.rs
@@ -1,0 +1,197 @@
+//! PGN viewer UI — renders the chess board + move history for a saved game.
+//!
+//! Re-uses the existing `render_game_ui` layout by syncing the PgnViewer's current
+//! position into `app.game.logic.game_board` before rendering.
+
+use crate::app::App;
+use crate::game_logic::game::GameState;
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Paragraph},
+    Frame,
+};
+
+/// Sync the PgnViewer's current ply into `app.game.logic.game_board` so that
+/// existing board/history render functions see the right position.
+pub fn sync_pgn_to_board(app: &mut App) {
+    let (positions, moves, current_ply) = {
+        if let Some(ref viewer) = app.pgn_viewer_state {
+            let v = &viewer[app.pgn_viewer_game_idx];
+            (
+                v.positions[..=v.current_ply].to_vec(),
+                v.moves[..v.current_ply].to_vec(),
+                v.current_ply,
+            )
+        } else {
+            return;
+        }
+    };
+
+    app.game.logic.game_board.position_history = positions;
+    app.game.logic.game_board.move_history = moves;
+    app.game.logic.game_board.history_position_index = None;
+    app.game.ui.selected_square = None;
+    app.game.logic.game_state = GameState::Playing;
+    // Set player_turn so history panel colouring is correct
+    app.game.logic.player_turn = if current_ply % 2 == 0 {
+        shakmaty::Color::White
+    } else {
+        shakmaty::Color::Black
+    };
+}
+
+pub fn render_pgn_viewer(frame: &mut Frame, app: &mut App) {
+    let area = frame.area();
+
+    // Split: board area (top) + footer bar (bottom)
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(0),    // board + history (reuses render_game_ui)
+            Constraint::Length(3), // footer with controls
+        ])
+        .split(area);
+
+    // Sync board state from PGN viewer
+    sync_pgn_to_board(app);
+
+    // Render the board using the existing game UI
+    super::main_ui::render_game_ui(frame, app, layout[0]);
+
+    // Footer
+    render_footer(frame, app, layout[1]);
+}
+
+fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
+    let viewer_opt = app
+        .pgn_viewer_state
+        .as_ref()
+        .and_then(|v| v.get(app.pgn_viewer_game_idx));
+
+    let (current_ply, total_plies, auto_play, speed, title, white, black, result, game_count) =
+        if let Some(v) = viewer_opt {
+            let count = app
+                .pgn_viewer_state
+                .as_ref()
+                .map(|gs| gs.len())
+                .unwrap_or(1);
+            (
+                v.current_ply,
+                v.total_plies(),
+                v.auto_play,
+                v.auto_play_speed,
+                v.title.as_str(),
+                v.white.as_str(),
+                v.black.as_str(),
+                v.result.as_str(),
+                count,
+            )
+        } else {
+            return;
+        };
+
+    let game_idx = app.pgn_viewer_game_idx + 1;
+
+    // Build footer text
+    let ply_str = if current_ply == 0 {
+        "Start".to_string()
+    } else {
+        let move_n = (current_ply + 1) / 2;
+        let side = if current_ply % 2 == 1 { "W" } else { "B" };
+        format!("Move {}.{}", move_n, side)
+    };
+
+    let play_icon = if auto_play { "⏸ Pause" } else { "▶ Play" };
+    let speed_str = match speed {
+        1 => "Fast",
+        2..=4 => "Normal",
+        _ => "Slow",
+    };
+
+    let nav_line = vec![
+        Span::styled("←/→", Style::default().fg(Color::Yellow)),
+        Span::raw(" Step  "),
+        Span::styled("Space", Style::default().fg(Color::Yellow)),
+        Span::raw(format!(" {}  ", play_icon)),
+        Span::styled("+/-", Style::default().fg(Color::Yellow)),
+        Span::raw(format!(" Speed:{speed_str}  ")),
+        Span::styled("g/G", Style::default().fg(Color::Yellow)),
+        Span::raw(" Start/End  "),
+        if game_count > 1 {
+            Span::styled(
+                format!("Tab → Next game ({}/{})", game_idx, game_count),
+                Style::default().fg(Color::Cyan),
+            )
+        } else {
+            Span::raw(String::new())
+        },
+        Span::styled("  Esc", Style::default().fg(Color::Yellow)),
+        Span::raw(" Quit"),
+    ];
+
+    // Progress bar
+    let progress = if total_plies > 0 {
+        let pct = current_ply * 20 / total_plies;
+        format!(
+            "[{}{}] {}/{}",
+            "█".repeat(pct),
+            "░".repeat(20 - pct),
+            current_ply,
+            total_plies
+        )
+    } else {
+        "[────────────────────] 0/0".to_string()
+    };
+
+    let header_str = format!(
+        "{} │ {} vs {} │ {} │  {}",
+        title, white, black, result, ply_str
+    );
+
+    let footer_block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    let inner = footer_block.inner(area);
+    frame.render_widget(footer_block, area);
+
+    // Two rows inside the footer
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Length(1)])
+        .split(inner);
+
+    // Row 1: game info + progress
+    let row1_layout = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(0), Constraint::Length(30)])
+        .split(rows[0]);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            header_str,
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]))
+        .alignment(Alignment::Left),
+        row1_layout[0],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            progress,
+            Style::default().fg(Color::Green),
+        )]))
+        .alignment(Alignment::Right),
+        row1_layout[1],
+    );
+
+    // Row 2: key hints
+    frame.render_widget(
+        Paragraph::new(Line::from(nav_line)).alignment(Alignment::Left),
+        rows[1],
+    );
+}

--- a/src/ui/pgn_viewer_ui.rs
+++ b/src/ui/pgn_viewer_ui.rs
@@ -4,14 +4,17 @@
 //! position into `app.game.logic.game_board` before rendering.
 
 use crate::app::App;
+use crate::game_logic::coord::Coord;
 use crate::game_logic::game::GameState;
 use ratatui::{
-    layout::{Alignment, Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Paragraph},
+    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap},
     Frame,
 };
+
+use super::main_ui::centered_rect;
 
 /// Sync the PgnViewer's current ply into `app.game.logic.game_board` so that
 /// existing board/history render functions see the right position.
@@ -34,6 +37,8 @@ pub fn sync_pgn_to_board(app: &mut App) {
     app.game.logic.game_board.history_position_index = None;
     app.game.ui.selected_square = None;
     app.game.logic.game_state = GameState::Playing;
+    // Hide the square cursor — viewer is read-only, nothing to select.
+    app.game.ui.cursor_coordinates = Coord::undefined();
     // Set player_turn so history panel colouring is correct
     app.game.logic.player_turn = if current_ply % 2 == 0 {
         shakmaty::Color::White
@@ -45,12 +50,13 @@ pub fn sync_pgn_to_board(app: &mut App) {
 pub fn render_pgn_viewer(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
 
-    // Split: board area (top) + footer bar (bottom)
+    // Split: board area (top) + footer bar (bottom).
+    // Footer needs 4 rows: 2 borders + 2 content lines (header + controls).
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(0),    // board + history (reuses render_game_ui)
-            Constraint::Length(3), // footer with controls
+            Constraint::Length(4), // footer with controls
         ])
         .split(area);
 
@@ -62,9 +68,13 @@ pub fn render_pgn_viewer(frame: &mut Frame, app: &mut App) {
 
     // Footer
     render_footer(frame, app, layout[1]);
+
+    // If sitting on the last position, overlay a small result banner
+    // over the sidebar so the outcome is immediately clear.
+    render_end_banner(frame, app, layout[0]);
 }
 
-fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
+fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
     let viewer_opt = app
         .pgn_viewer_state
         .as_ref()
@@ -94,7 +104,6 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
 
     let game_idx = app.pgn_viewer_game_idx + 1;
 
-    // Build footer text
     let ply_str = if current_ply == 0 {
         "Start".to_string()
     } else {
@@ -103,35 +112,38 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         format!("Move {}.{}", move_n, side)
     };
 
-    let play_icon = if auto_play { "⏸ Pause" } else { "▶ Play" };
+    let play_label = if auto_play { "Pause" } else { "Play" };
     let speed_str = match speed {
         1 => "Fast",
         2..=4 => "Normal",
         _ => "Slow",
     };
 
-    let nav_line = vec![
-        Span::styled("←/→", Style::default().fg(Color::Yellow)),
-        Span::raw(" Step  "),
-        Span::styled("Space", Style::default().fg(Color::Yellow)),
-        Span::raw(format!(" {}  ", play_icon)),
-        Span::styled("+/-", Style::default().fg(Color::Yellow)),
+    let mut nav_spans = vec![
+        Span::styled("←/→", Style::default().fg(Color::Cyan)),
+        Span::raw(" or "),
+        Span::styled("P/N", Style::default().fg(Color::Cyan)),
+        Span::raw(" Prev/Next  "),
+        Span::styled("Space", Style::default().fg(Color::Cyan)),
+        Span::raw(format!(" {}  ", play_label)),
+        Span::styled("+/-", Style::default().fg(Color::Cyan)),
         Span::raw(format!(" Speed:{speed_str}  ")),
-        Span::styled("g/G", Style::default().fg(Color::Yellow)),
+        Span::styled("g/G", Style::default().fg(Color::Cyan)),
         Span::raw(" Start/End  "),
-        if game_count > 1 {
-            Span::styled(
-                format!("Tab → Next game ({}/{})", game_idx, game_count),
-                Style::default().fg(Color::Cyan),
-            )
-        } else {
-            Span::raw(String::new())
-        },
-        Span::styled("  Esc", Style::default().fg(Color::Yellow)),
-        Span::raw(" Quit"),
     ];
+    if game_count > 1 {
+        nav_spans.push(Span::styled(
+            format!("Tab {}/{}  ", game_idx, game_count),
+            Style::default().fg(Color::Cyan),
+        ));
+    }
+    nav_spans.extend([
+        Span::styled("?", Style::default().fg(Color::Cyan)),
+        Span::raw(" Help  "),
+        Span::styled("Esc", Style::default().fg(Color::Cyan)),
+        Span::raw(" Back"),
+    ]);
 
-    // Progress bar
     let progress = if total_plies > 0 {
         let pct = current_ply * 20 / total_plies;
         format!(
@@ -158,13 +170,11 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     let inner = footer_block.inner(area);
     frame.render_widget(footer_block, area);
 
-    // Two rows inside the footer
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(1), Constraint::Length(1)])
         .split(inner);
 
-    // Row 1: game info + progress
     let row1_layout = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Min(0), Constraint::Length(30)])
@@ -189,9 +199,81 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         row1_layout[1],
     );
 
-    // Row 2: key hints
     frame.render_widget(
-        Paragraph::new(Line::from(nav_line)).alignment(Alignment::Left),
+        Paragraph::new(Line::from(nav_spans)).alignment(Alignment::Center),
         rows[1],
     );
+}
+
+/// When the viewer sits on the final position, overlay a small banner with
+/// the final result and termination reason. Non-modal — navigation keys
+/// continue to work and the banner disappears as soon as the user steps back.
+fn render_end_banner(frame: &mut Frame, app: &App, board_area: Rect) {
+    let Some(viewer) = app
+        .pgn_viewer_state
+        .as_ref()
+        .and_then(|v| v.get(app.pgn_viewer_game_idx))
+    else {
+        return;
+    };
+
+    if !viewer.is_at_end() {
+        return;
+    }
+
+    let area = centered_rect(45, 28, board_area);
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "Game Over",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .alignment(Alignment::Center),
+        Line::from(""),
+        Line::from(Span::styled(
+            viewer.result_summary(),
+            Style::default()
+                .fg(Color::LightGreen)
+                .add_modifier(Modifier::BOLD),
+        ))
+        .alignment(Alignment::Center),
+    ];
+    if !viewer.termination.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(
+            Line::from(Span::styled(
+                viewer.termination.clone(),
+                Style::default().fg(Color::Gray),
+            ))
+            .alignment(Alignment::Center),
+        );
+    }
+    lines.extend([
+        Line::from(""),
+        Line::from(Span::styled(
+            "← / P to step back",
+            Style::default().fg(Color::DarkGray),
+        ))
+        .alignment(Alignment::Center),
+    ]);
+
+    let block = Block::default()
+        .title(" Result ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_type(BorderType::Double)
+        .border_style(Style::default().fg(Color::Yellow))
+        .padding(Padding::horizontal(1))
+        .style(Style::default().bg(Color::DarkGray));
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: true });
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(paragraph, area);
 }

--- a/src/ui/pgn_viewer_ui.rs
+++ b/src/ui/pgn_viewer_ui.rs
@@ -98,7 +98,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     let ply_str = if current_ply == 0 {
         "Start".to_string()
     } else {
-        let move_n = (current_ply + 1) / 2;
+        let move_n = (current_ply + 1).div_ceil(2);
         let side = if current_ply % 2 == 1 { "W" } else { "B" };
         format!("Move {}.{}", move_n, side)
     };

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -448,8 +448,58 @@ pub fn render_credit_popup(frame: &mut Frame) {
     frame.render_widget(paragraph, area);
 }
 
+/// Help popup shown while the PGN viewer is active. Covers only the controls
+/// that make sense for a read-only replay - no piece-selection or skin cycling.
+fn render_pgn_help_popup(frame: &mut Frame) {
+    let block = Block::default()
+        .title("PGN viewer - controls")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
+        .border_style(Style::default().fg(WHITE));
+    let area = centered_rect(45, 55, frame.area());
+
+    let text = vec![
+        Line::from("Navigation".underlined().bold()),
+        Line::from(""),
+        Line::from("→ / N / l : Next move"),
+        Line::from("← / P / h : Previous move"),
+        Line::from("g         : Jump to start"),
+        Line::from("G         : Jump to end"),
+        Line::from("Tab       : Next game (multi-game PGN)"),
+        Line::from(""),
+        Line::from("Auto-play".underlined().bold()),
+        Line::from(""),
+        Line::from("Space     : Play / Pause"),
+        Line::from("+  /  -   : Speed up / slow down"),
+        Line::from("            (0.5x, 1x, 1.5x, 2x, 2.5x, 3x, 4x)"),
+        Line::from(""),
+        Line::from("Other".underlined().bold()),
+        Line::from(""),
+        Line::from("h         : Hide the end-of-game banner"),
+        Line::from("?         : Toggle this help"),
+        Line::from("Esc / q   : Exit the viewer"),
+        Line::from(""),
+        Line::from("Press `Esc` or `?` to close.").alignment(Alignment::Center),
+    ];
+
+    let paragraph = Paragraph::new(text)
+        .block(block.clone())
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: true });
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(block, area);
+    frame.render_widget(paragraph, area);
+}
+
 // This render the help popup
 pub fn render_help_popup(frame: &mut Frame, app: &crate::app::App) {
+    if app.current_page == crate::constants::Pages::PgnViewer {
+        render_pgn_help_popup(frame);
+        return;
+    }
+
     let block = Block::default()
         .title("Help menu")
         .borders(Borders::ALL)

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -735,6 +735,44 @@ pub fn render_enter_multiplayer_ip(frame: &mut Frame, prompt: &Prompt) {
     frame.render_widget(paragraph, area);
 }
 
+// This renders a popup for entering the path to a PGN file
+pub fn render_load_pgn_popup(frame: &mut Frame, prompt: &Prompt) {
+    let block = Block::default()
+        .title("Load PGN")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
+        .border_style(Style::default().fg(WHITE));
+    let area = centered_rect(60, 35, frame.area());
+
+    let current_input = prompt.input.as_str();
+
+    let text = vec![
+        Line::from("Enter the absolute path to a .pgn file:").alignment(Alignment::Center),
+        Line::from(""),
+        Line::from(current_input),
+        Line::from(""),
+        Line::from(""),
+        Line::from("Multi-game PGN files are supported."),
+        Line::from(""),
+        Line::from("Press `Enter` to load, `Esc` to cancel.").alignment(Alignment::Center),
+    ];
+
+    let paragraph = Paragraph::new(text)
+        .block(block.clone())
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: true });
+
+    frame.set_cursor_position(Position::new(
+        area.x + prompt.character_index as u16 + 2,
+        area.y + 3,
+    ));
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(block, area);
+    frame.render_widget(paragraph, area);
+}
+
 // This renders a popup allowing us to enter a game code to join a Lichess game
 pub fn render_enter_game_code_popup(frame: &mut Frame, prompt: &Prompt) {
     let block = Block::default()

--- a/tests/pgn_viewer_integration.rs
+++ b/tests/pgn_viewer_integration.rs
@@ -82,12 +82,18 @@ fn h_dismisses_end_banner_and_step_back_restores_it() -> AppResult<()> {
     let end_ply = app.pgn_viewer_state.as_ref().unwrap()[0].current_ply;
     send(&mut app, &[KeyCode::Char('h')])?;
     let v = &app.pgn_viewer_state.as_ref().unwrap()[0];
-    assert_eq!(v.current_ply, end_ply, "h must not step back when banner is visible");
+    assert_eq!(
+        v.current_ply, end_ply,
+        "h must not step back when banner is visible"
+    );
     assert!(v.end_banner_dismissed);
 
     // After dismissal, `h` falls through to Previous move.
     send(&mut app, &[KeyCode::Char('h')])?;
-    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].current_ply, end_ply - 1);
+    assert_eq!(
+        app.pgn_viewer_state.as_ref().unwrap()[0].current_ply,
+        end_ply - 1
+    );
 
     // Stepping back clears the dismissal so re-entering the end shows it again.
     assert!(!app.pgn_viewer_state.as_ref().unwrap()[0].end_banner_dismissed);
@@ -100,24 +106,48 @@ fn h_dismisses_end_banner_and_step_back_restores_it() -> AppResult<()> {
 #[test]
 fn speed_steps_through_multipliers() -> AppResult<()> {
     let mut app = load_sample_viewer();
-    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "1x");
+    assert_eq!(
+        app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(),
+        "1x"
+    );
 
     send(&mut app, &[KeyCode::Char('+')])?;
-    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "1.5x");
+    assert_eq!(
+        app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(),
+        "1.5x"
+    );
     send(&mut app, &[KeyCode::Char('+')])?;
-    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "2x");
+    assert_eq!(
+        app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(),
+        "2x"
+    );
     send(&mut app, &[KeyCode::Char('+')])?;
-    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "2.5x");
+    assert_eq!(
+        app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(),
+        "2.5x"
+    );
     send(&mut app, &[KeyCode::Char('+')])?;
-    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "3x");
+    assert_eq!(
+        app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(),
+        "3x"
+    );
     send(&mut app, &[KeyCode::Char('+')])?;
-    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "4x");
+    assert_eq!(
+        app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(),
+        "4x"
+    );
     // Capped
     send(&mut app, &[KeyCode::Char('+')])?;
-    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "4x");
+    assert_eq!(
+        app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(),
+        "4x"
+    );
 
     send(&mut app, &[KeyCode::Char('-')])?;
-    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "3x");
+    assert_eq!(
+        app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(),
+        "3x"
+    );
     Ok(())
 }
 
@@ -137,7 +167,10 @@ fn esc_returns_home_and_does_not_leave_stale_state() -> AppResult<()> {
     assert_eq!(app.current_page, Pages::Home);
     assert!(app.pgn_viewer_state.is_none());
     // The critical checks - nothing from the viewer leaks into a fresh game.
-    assert!(!app.game.ui.hide_cursor, "cursor must be visible after exit");
+    assert!(
+        !app.game.ui.hide_cursor,
+        "cursor must be visible after exit"
+    );
     assert_eq!(
         app.game.logic.game_board.position_history.len(),
         1,
@@ -158,10 +191,7 @@ fn can_start_new_local_game_after_viewing_pgn() -> AppResult<()> {
     assert_eq!(app.current_page, Pages::Home);
 
     // Home → Play Game → Local → start game
-    send(
-        &mut app,
-        &[KeyCode::Enter, KeyCode::Enter, KeyCode::Enter],
-    )?;
+    send(&mut app, &[KeyCode::Enter, KeyCode::Enter, KeyCode::Enter])?;
     assert_eq!(app.current_page, Pages::Solo);
     assert!(!app.game.ui.hide_cursor);
     Ok(())

--- a/tests/pgn_viewer_integration.rs
+++ b/tests/pgn_viewer_integration.rs
@@ -1,0 +1,168 @@
+//! End-to-end checks for the PGN viewer feedback items.
+//!
+//! These drive the public event handler exactly the way the terminal would,
+//! so the assertions prove the observable behaviour the maintainer asked for.
+
+use chess_tui::{
+    app::{App, AppResult},
+    constants::{Pages, Popups},
+    handler::handle_key_events,
+    pgn_viewer::PgnViewer,
+};
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent {
+        code,
+        modifiers: KeyModifiers::empty(),
+        kind: KeyEventKind::Press,
+        state: ratatui::crossterm::event::KeyEventState::empty(),
+    }
+}
+
+fn send(app: &mut App, keys: &[KeyCode]) -> AppResult<()> {
+    for &k in keys {
+        handle_key_events(key(k), app)?;
+    }
+    Ok(())
+}
+
+fn load_sample_viewer() -> App {
+    let games =
+        PgnViewer::from_file("examples/sample.pgn").expect("examples/sample.pgn should parse");
+    let mut app = App::default();
+    app.pgn_viewer_state = Some(games);
+    app.pgn_viewer_game_idx = 0;
+    app.current_page = Pages::PgnViewer;
+    app
+}
+
+#[test]
+fn help_popup_opens_in_pgn_mode() -> AppResult<()> {
+    let mut app = load_sample_viewer();
+    send(&mut app, &[KeyCode::Char('?')])?;
+    assert_eq!(app.current_popup, Some(Popups::Help));
+    send(&mut app, &[KeyCode::Char('?')])?;
+    assert_eq!(app.current_popup, None);
+    Ok(())
+}
+
+#[test]
+fn p_and_n_navigate_prev_next() -> AppResult<()> {
+    let mut app = load_sample_viewer();
+    send(&mut app, &[KeyCode::Char('N'), KeyCode::Char('N')])?;
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].current_ply, 2);
+    send(&mut app, &[KeyCode::Char('P')])?;
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].current_ply, 1);
+    Ok(())
+}
+
+#[test]
+fn g_and_capital_g_jump_to_start_and_end() -> AppResult<()> {
+    let mut app = load_sample_viewer();
+    send(&mut app, &[KeyCode::Char('G')])?;
+    let v = &app.pgn_viewer_state.as_ref().unwrap()[0];
+    assert!(v.is_at_end());
+    let total = v.total_plies();
+
+    send(&mut app, &[KeyCode::Char('g')])?;
+    let v = &app.pgn_viewer_state.as_ref().unwrap()[0];
+    assert_eq!(v.current_ply, 0);
+    assert!(total > 0);
+    Ok(())
+}
+
+#[test]
+fn h_dismisses_end_banner_and_step_back_restores_it() -> AppResult<()> {
+    let mut app = load_sample_viewer();
+    send(&mut app, &[KeyCode::Char('G')])?;
+    assert!(app.pgn_viewer_state.as_ref().unwrap()[0].is_at_end());
+
+    // Pressing `h` at the end banner should hide it, NOT step back.
+    let end_ply = app.pgn_viewer_state.as_ref().unwrap()[0].current_ply;
+    send(&mut app, &[KeyCode::Char('h')])?;
+    let v = &app.pgn_viewer_state.as_ref().unwrap()[0];
+    assert_eq!(v.current_ply, end_ply, "h must not step back when banner is visible");
+    assert!(v.end_banner_dismissed);
+
+    // After dismissal, `h` falls through to Previous move.
+    send(&mut app, &[KeyCode::Char('h')])?;
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].current_ply, end_ply - 1);
+
+    // Stepping back clears the dismissal so re-entering the end shows it again.
+    assert!(!app.pgn_viewer_state.as_ref().unwrap()[0].end_banner_dismissed);
+    send(&mut app, &[KeyCode::Char('N')])?;
+    assert!(app.pgn_viewer_state.as_ref().unwrap()[0].is_at_end());
+    assert!(!app.pgn_viewer_state.as_ref().unwrap()[0].end_banner_dismissed);
+    Ok(())
+}
+
+#[test]
+fn speed_steps_through_multipliers() -> AppResult<()> {
+    let mut app = load_sample_viewer();
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "1x");
+
+    send(&mut app, &[KeyCode::Char('+')])?;
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "1.5x");
+    send(&mut app, &[KeyCode::Char('+')])?;
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "2x");
+    send(&mut app, &[KeyCode::Char('+')])?;
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "2.5x");
+    send(&mut app, &[KeyCode::Char('+')])?;
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "3x");
+    send(&mut app, &[KeyCode::Char('+')])?;
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "4x");
+    // Capped
+    send(&mut app, &[KeyCode::Char('+')])?;
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "4x");
+
+    send(&mut app, &[KeyCode::Char('-')])?;
+    assert_eq!(app.pgn_viewer_state.as_ref().unwrap()[0].speed_label(), "3x");
+    Ok(())
+}
+
+#[test]
+fn esc_returns_home_and_does_not_leave_stale_state() -> AppResult<()> {
+    let mut app = load_sample_viewer();
+
+    // Inject the state that a real render pass would install.
+    use chess_tui::ui::pgn_viewer_ui::sync_pgn_to_board;
+    sync_pgn_to_board(&mut app);
+    assert!(app.game.ui.hide_cursor, "precondition: viewer hides cursor");
+    assert!(!app.game.logic.game_board.position_history.is_empty());
+
+    // Exit viewer with Esc.
+    send(&mut app, &[KeyCode::Esc])?;
+
+    assert_eq!(app.current_page, Pages::Home);
+    assert!(app.pgn_viewer_state.is_none());
+    // The critical checks - nothing from the viewer leaks into a fresh game.
+    assert!(!app.game.ui.hide_cursor, "cursor must be visible after exit");
+    assert_eq!(
+        app.game.logic.game_board.position_history.len(),
+        1,
+        "new game must start with just the initial position"
+    );
+    assert!(app.game.logic.game_board.move_history.is_empty());
+    Ok(())
+}
+
+#[test]
+fn can_start_new_local_game_after_viewing_pgn() -> AppResult<()> {
+    let mut app = load_sample_viewer();
+    use chess_tui::ui::pgn_viewer_ui::sync_pgn_to_board;
+    sync_pgn_to_board(&mut app);
+
+    // Exit PGN viewer.
+    send(&mut app, &[KeyCode::Esc])?;
+    assert_eq!(app.current_page, Pages::Home);
+
+    // Home → Play Game → Local → start game
+    send(
+        &mut app,
+        &[KeyCode::Enter, KeyCode::Enter, KeyCode::Enter],
+    )?;
+    assert_eq!(app.current_page, Pages::Solo);
+    assert!(!app.game.ui.hide_cursor);
+    Ok(())
+}


### PR DESCRIPTION
  PGN Import and Visualization
                                                                                           
  Description 

  Adds the ability to load a .pgn file directly into chess-tui and step through the games  
  inside it. You can navigate move by move, jump to start/end, and let it auto-play at
  slow/normal/fast speed. Multi-game PGN files are supported — you can cycle between games 
  in the same file.

  The viewer shows the board position, the move history panel with the current ply         
  highlighted, and metadata from the PGN headers (White, Black, Result).
                                                                                           
  Launched via a --pgn <file> CLI flag.                                                    
   
  How Has This Been Tested?                                                                
              
  - Loaded single-game and multi-game PGN files and verified all positions render correctly
  - Tested forward/backward navigation, jump-to-start, jump-to-end
  - Tested auto-play at all three speeds                                                   
  - Verified graceful error on missing or malformed PGN file
  
  fixes: #25 
                                                                                           
  Checklist:  
                                                                                           
  - My code follows the style guidelines of this project
  - I have performed a self-review of my code
  - I have commented my code, particularly in hard-to-understand areas
  - I have made corresponding changes to the documentation                                 
  - My changes generate no new warnings
  - I have added tests that prove my fix is effective or that my feature works             
  - New and existing unit tests pass locally with my changes
  - Any dependent changes have been merged and published in downstream modules 