### PR TITLE
feat: loading popup + async methods for lichess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "shakmaty",
  "simplelog",
  "tempfile",
+ "throbber-widgets-tui",
  "toml",
 ]
 
@@ -3187,6 +3188,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "throbber-widgets-tui"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e6941f74491a80911cb8821cb1f55f7e13bca867b28a2b14e5a1daaf691eb3"
+dependencies = [
+ "ratatui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = "1.0"
 reqwest = { version = "0.13", features = ["blocking", "json", "form"] }
 rodio = { version = "0.22", optional = true }
 rand = "0.10.1"
+throbber-widgets-tui = "0.11.0"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/src/app/lichess.rs
+++ b/src/app/lichess.rs
@@ -205,7 +205,8 @@ impl App {
                 }
                 // We received an update from the profile fetch
                 LichessUpdate::ProfileLoaded(result) => match result {
-                    Ok((profile, history)) => {
+                    Ok(data) => {
+                        let (profile, history) = *data;
                         self.lichess_state.user_profile = Some(profile);
                         self.lichess_state.rating_history = Some(history);
                     }
@@ -553,7 +554,9 @@ impl App {
             Ok(profile) => {
                 let username = profile.username.clone();
                 let history = client.get_rating_history(&username).unwrap_or_default();
-                let _ = tx.send(LichessUpdate::ProfileLoaded(Ok((profile, history))));
+                let _ = tx.send(LichessUpdate::ProfileLoaded(Ok(Box::new((
+                    profile, history,
+                )))));
             }
             Err(e) => {
                 let _ = tx.send(LichessUpdate::ProfileLoaded(Err(e.to_string())));

--- a/src/app/lichess.rs
+++ b/src/app/lichess.rs
@@ -6,6 +6,7 @@ use crate::game_logic::game::GameState;
 use crate::game_logic::opponent::Opponent;
 use crate::game_logic::puzzle::PuzzleGame;
 use crate::lichess::models::LichessClient;
+use crate::state::lichess_state::LichessUpdate;
 use shakmaty::Color;
 use std::sync::mpsc::channel;
 
@@ -96,7 +97,7 @@ impl App {
         let client = client.clone();
 
         let (tx, rx) = channel();
-        self.lichess_state.seek_receiver = Some(rx);
+        self.lichess_state.receiver = Some(rx);
 
         let cancellation_token = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         self.lichess_state.cancellation_token = Some(cancellation_token.clone());
@@ -108,10 +109,10 @@ impl App {
             // Using 0,0 which will trigger the days parameter in seek_game
             match client.seek_game(0, 0, cancellation_token) {
                 Ok((game_id, color)) => {
-                    let _ = tx.send(Ok((game_id, color)));
+                    let _ = tx.send(LichessUpdate::SeekResult(Ok((game_id, color))));
                 }
                 Err(e) => {
-                    let _ = tx.send(Err(e.to_string()));
+                    let _ = tx.send(LichessUpdate::SeekResult(Err(e.to_string())));
                 }
             }
         });
@@ -132,7 +133,7 @@ impl App {
         let client = client.clone();
 
         let (tx, rx) = channel();
-        self.lichess_state.seek_receiver = Some(rx);
+        self.lichess_state.receiver = Some(rx);
 
         self.ui_state.current_popup = Some(Popups::SeekingLichessGame);
 
@@ -152,7 +153,10 @@ impl App {
             let my_id = match client.get_user_profile() {
                 Ok(profile) => profile.id,
                 Err(e) => {
-                    let _ = tx.send(Err(format!("Failed to fetch profile: {}", e)));
+                    let _ = tx.send(LichessUpdate::SeekResult(Err(format!(
+                        "Failed to fetch profile: {}",
+                        e
+                    ))));
                     return;
                 }
             };
@@ -160,42 +164,60 @@ impl App {
             // Join the game by code
             match client.join_game(&game_id, my_id) {
                 Ok((game_id, color)) => {
-                    let _ = tx.send(Ok((game_id, color)));
+                    let _ = tx.send(LichessUpdate::SeekResult(Ok((game_id, color))));
                 }
                 Err(e) => {
-                    let _ = tx.send(Err(e.to_string()));
+                    let _ = tx.send(LichessUpdate::SeekResult(Err(e.to_string())));
                 }
             }
         });
     }
 
-    /// Polls the seek channel once per tick. On success, sets up the game board and switches to
-    /// the Lichess page. On error, shows an error popup.
-    pub fn check_lichess_seek(&mut self) {
-        if let Some(rx) = &self.lichess_state.seek_receiver
-            && let Ok(result) = rx.try_recv()
+    /// Polls the shared background channel once per tick and dispatches on message type.
+    pub fn check_lichess_updates(&mut self) {
+        if let Some(rx) = &self.lichess_state.receiver
+            && let Ok(update) = rx.try_recv()
         {
-            self.lichess_state.seek_receiver = None;
+            self.lichess_state.receiver = None;
             self.ui_state.close_popup();
 
-            // Cancel the seek since we found a game (or got an error)
-            if let Some(cancellation_token) = &self.lichess_state.cancellation_token {
-                cancellation_token.store(true, std::sync::atomic::Ordering::Relaxed);
-                log::info!("Cancelling Lichess seek - game found or error occurred");
-            }
-            self.lichess_state.cancellation_token = None;
+            match update {
+                // We received an seek fetch
+                LichessUpdate::SeekResult(result) => {
+                    if let Some(cancellation_token) = &self.lichess_state.cancellation_token {
+                        cancellation_token.store(true, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    self.lichess_state.cancellation_token = None;
 
-            match result {
-                Ok((game_id, color)) => {
-                    log::info!("Found Lichess game: {} with color {:?}", game_id, color);
-                    // Use the helper function to set up the game with state
-                    self.setup_lichess_game_with_state(game_id, color, None);
+                    match result {
+                        Ok((game_id, color)) => {
+                            log::info!("Found Lichess game: {} with color {:?}", game_id, color);
+                            self.setup_lichess_game_with_state(game_id, color, None);
+                        }
+                        Err(e) => {
+                            log::error!("Failed to seek Lichess game: {}", e);
+                            self.ui_state.show_message_popup(
+                                format!("Failed to seek game: {}", e),
+                                Popups::Error,
+                            );
+                        }
+                    }
                 }
-                Err(e) => {
-                    log::error!("Failed to seek Lichess game: {}", e);
-                    self.ui_state
-                        .show_message_popup(format!("Failed to seek game: {}", e), Popups::Error);
-                }
+                // We received an update from the profile fetch
+                LichessUpdate::ProfileLoaded(result) => match result {
+                    Ok((profile, history)) => {
+                        self.lichess_state.user_profile = Some(profile);
+                        self.lichess_state.rating_history = Some(history);
+                    }
+                    Err(e) => {
+                        log::error!("Failed to fetch user profile: {}", e);
+                        self.ui_state.show_message_popup(
+                            "An error occured when trying to fetch your lichess profile"
+                                .to_string(),
+                            Popups::Error,
+                        );
+                    }
+                },
             }
         }
     }
@@ -511,7 +533,8 @@ impl App {
         }
     }
 
-    /// Fetches the user profile and rating history from Lichess and stores them in `lichess_state`.
+    /// Spawns a background thread to fetch the user profile and rating history.
+    /// The result is polled each tick via `check_lichess_profile_loaded`.
     pub fn fetch_lichess_user_profile(&mut self) {
         let Ok(client) = self.lichess_state.require_client() else {
             self.ui_state.show_message_popup(
@@ -523,27 +546,19 @@ impl App {
         };
 
         let client = client.clone();
+        let (tx, rx) = channel();
+        self.lichess_state.receiver = Some(rx);
 
-        match client.get_user_profile() {
+        std::thread::spawn(move || match client.get_user_profile() {
             Ok(profile) => {
                 let username = profile.username.clone();
-                self.lichess_state.user_profile = Some(profile);
-
-                // Fetch rating history for the line chart
-                match client.get_rating_history(&username) {
-                    Ok(history) => {
-                        self.lichess_state.rating_history = Some(history);
-                    }
-                    Err(e) => {
-                        log::error!("Failed to fetch rating history: {}", e);
-                    }
-                }
+                let history = client.get_rating_history(&username).unwrap_or_default();
+                let _ = tx.send(LichessUpdate::ProfileLoaded(Ok((profile, history))));
             }
             Err(e) => {
-                log::error!("Failed to fetch user profile: {}", e);
-                // Don't show error popup, just log it
+                let _ = tx.send(LichessUpdate::ProfileLoaded(Err(e.to_string())));
             }
-        }
+        });
     }
 
     /// Joins the ongoing Lichess game at the current menu cursor position, restoring board state from FEN.

--- a/src/app/lichess.rs
+++ b/src/app/lichess.rs
@@ -204,7 +204,7 @@ impl App {
                     }
                 }
                 // We received an update from the profile fetch
-                LichessUpdate::ProfileLoaded(result) => match result {
+                LichessUpdate::ProfileResult(result) => match result {
                     Ok(data) => {
                         let (profile, history) = *data;
                         self.lichess_state.user_profile = Some(profile);
@@ -215,6 +215,19 @@ impl App {
                         self.ui_state.show_message_popup(
                             "An error occured when trying to fetch your lichess profile"
                                 .to_string(),
+                            Popups::Error,
+                        );
+                    }
+                },
+                LichessUpdate::OngoingGamesResult(result) => match result {
+                    Ok(games) => {
+                        self.lichess_state.ongoing_games = games;
+                        self.ui_state.close_popup();
+                    }
+                    Err(e) => {
+                        log::error!("Failed to fetch ongoing games: {}", e);
+                        self.ui_state.show_message_popup(
+                            format!("Failed to fetch ongoing games: {}", e),
                             Popups::Error,
                         );
                     }
@@ -440,18 +453,18 @@ impl App {
             return;
         };
 
-        match client.get_ongoing_games() {
+        let client = client.clone();
+        let (tx, rx) = channel();
+        self.lichess_state.receiver = Some(rx);
+
+        std::thread::spawn(move || match client.get_ongoing_games() {
             Ok(games) => {
-                self.lichess_state.ongoing_games = games;
+                let _ = tx.send(LichessUpdate::OngoingGamesResult(Ok(games)));
             }
             Err(e) => {
-                log::error!("Failed to fetch ongoing games: {}", e);
-                self.ui_state.show_message_popup(
-                    format!("Failed to fetch ongoing games: {}", e),
-                    Popups::Error,
-                );
+                let _ = tx.send(LichessUpdate::OngoingGamesResult(Err(e.to_string())));
             }
-        }
+        });
     }
 
     /// Opens the resign confirmation popup if a game is selected in the ongoing games list.
@@ -554,12 +567,12 @@ impl App {
             Ok(profile) => {
                 let username = profile.username.clone();
                 let history = client.get_rating_history(&username).unwrap_or_default();
-                let _ = tx.send(LichessUpdate::ProfileLoaded(Ok(Box::new((
+                let _ = tx.send(LichessUpdate::ProfileResult(Ok(Box::new((
                     profile, history,
                 )))));
             }
             Err(e) => {
-                let _ = tx.send(LichessUpdate::ProfileLoaded(Err(e.to_string())));
+                let _ = tx.send(LichessUpdate::ProfileResult(Err(e.to_string())));
             }
         });
     }

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -62,7 +62,11 @@ impl App {
                 }
                 self.ui_state.menu_cursor = 0;
                 self.ui_state.current_page = Pages::LichessMenu;
-                // Fetch user profile when entering Lichess menu
+                if self.lichess_state.user_profile.is_none() {
+                    self.ui_state.popup_message =
+                        Some("Loading your lichess account ...".to_string());
+                    self.ui_state.show_popup(Popups::Loading);
+                }
                 self.fetch_lichess_user_profile();
             }
             MainMenuItems::SkinSelector => {
@@ -128,7 +132,7 @@ impl App {
             log::info!("Cancelling Lichess seek before returning to home");
         }
         self.lichess_state.cancellation_token = None;
-        self.lichess_state.seek_receiver = None;
+        self.lichess_state.receiver = None;
 
         // Reset game-related state
         self.game_mode_state.selected_color = None;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -171,6 +171,8 @@ pub enum Popups {
     MoveInputSelection,
     /// File path entry for loading a PGN file.
     LoadPgnPath,
+    /// Spinner to make user wait
+    Loading,
 }
 
 /// Base URL for all Lichess REST API requests.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,6 +4,13 @@ use core::fmt;
 use std::path::PathBuf;
 
 use ratatui::style::Color;
+use throbber_widgets_tui::Set;
+
+pub const CHESS_SET: Set = Set {
+    full: "♚",
+    empty: " ",
+    symbols: &["♚", "♛", "♜", "♝", "♞", "♟", "♔", "♕", "♖", "♗", "♘", "♙"],
+};
 
 /// Sentinel value meaning "no board position set" (used before a square is chosen).
 pub const UNDEFINED_POSITION: u8 = u8::MAX;

--- a/src/game_logic/puzzle.rs
+++ b/src/game_logic/puzzle.rs
@@ -1,6 +1,5 @@
 //! Lichess puzzle state and move validation.
 
-use crate::constants::SLEEP_DURATION_PUZZLE_MS;
 use crate::game_logic::game::Game;
 use crate::game_logic::game::GameState;
 use crate::game_logic::game_board::GameBoard;
@@ -191,26 +190,14 @@ impl PuzzleGame {
 
             let puzzle_id = self.puzzle.puzzle.id.clone();
             let client = LichessClient::new(token);
-            let puzzle_rating_before = self.rating_before;
 
             let (tx, rx) = std::sync::mpsc::channel();
             self.elo_change_receiver = Some(rx);
 
             std::thread::spawn(move || {
-                if client
-                    .submit_puzzle_result(&puzzle_id, win, Some(time_ms))
-                    .is_ok()
+                if let Ok(rating_diff) = client.submit_puzzle_result(&puzzle_id, win, Some(time_ms))
                 {
-                    std::thread::sleep(Duration::from_millis(SLEEP_DURATION_PUZZLE_MS));
-                    if let Ok(updated_profile) = client.get_user_profile()
-                        && let Some(perfs) = &updated_profile.perfs
-                        && let Some(puzzle_perf) = &perfs.puzzle
-                        && let Some(rating_before) = puzzle_rating_before
-                    {
-                        let rating_after = puzzle_perf.rating;
-                        let elo_change = rating_after as i32 - rating_before as i32;
-                        let _ = tx.send(elo_change);
-                    }
+                    let _ = tx.send(rating_diff);
                 }
             });
 

--- a/src/game_logic/puzzle.rs
+++ b/src/game_logic/puzzle.rs
@@ -17,13 +17,13 @@ pub struct PuzzleGame {
     pub start_time: Option<Instant>,
     pub has_mistakes: bool,
     pub submitted: bool,
-    pub rating_before: Option<u32>,
+    pub rating_before: Option<u16>,
     pub elo_change: Option<i32>,
     pub elo_change_receiver: Option<Receiver<i32>>,
 }
 
 impl PuzzleGame {
-    pub fn new(puzzle: Puzzle, rating_before: Option<u32>) -> Self {
+    pub fn new(puzzle: Puzzle, rating_before: Option<u16>) -> Self {
         Self {
             puzzle,
             solution_index: 0,

--- a/src/handlers/lichess/lichess_menu.rs
+++ b/src/handlers/lichess/lichess_menu.rs
@@ -7,6 +7,27 @@ use crate::{
 };
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
+pub enum LichessMenuItems {
+    SeekGame,
+    Puzzle,
+    MyOngoingGames,
+    JoinByCode,
+    Disconnect,
+}
+
+impl From<u8> for LichessMenuItems {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => LichessMenuItems::SeekGame,
+            1 => LichessMenuItems::Puzzle,
+            2 => LichessMenuItems::MyOngoingGames,
+            3 => LichessMenuItems::JoinByCode,
+            4 => LichessMenuItems::Disconnect,
+            _ => unreachable!("Invalid LichessMenuItems value: {value}"),
+        }
+    }
+}
+
 /// Handles keyboard input on the Lichess menu page.
 /// Supports navigation through menu items and selection.
 pub fn handle_lichess_menu_page_events(app: &mut App, key_event: KeyEvent) {
@@ -14,9 +35,10 @@ pub fn handle_lichess_menu_page_events(app: &mut App, key_event: KeyEvent) {
         KeyCode::Up | KeyCode::Char('k') => app.ui_state.menu_cursor_up(5), // 5 menu options
         KeyCode::Down | KeyCode::Char('j') => app.ui_state.menu_cursor_down(5),
         KeyCode::Char(' ') | KeyCode::Enter => {
+            let item = LichessMenuItems::from(app.ui_state.menu_cursor);
             // Handle menu selection
-            match app.ui_state.menu_cursor {
-                0 => {
+            match item {
+                LichessMenuItems::SeekGame => {
                     // Seek Game
                     if app.lichess_state.token.is_none()
                         || app
@@ -36,7 +58,7 @@ pub fn handle_lichess_menu_page_events(app: &mut App, key_event: KeyEvent) {
                     app.ui_state.current_page = Pages::Lichess;
                     app.create_lichess_opponent();
                 }
-                1 => {
+                LichessMenuItems::Puzzle => {
                     // Puzzle
                     if app.lichess_state.token.is_none()
                         || app
@@ -54,7 +76,7 @@ pub fn handle_lichess_menu_page_events(app: &mut App, key_event: KeyEvent) {
                     }
                     app.start_puzzle_mode();
                 }
-                2 => {
+                LichessMenuItems::MyOngoingGames => {
                     // My Ongoing Games
                     if app.lichess_state.token.is_none()
                         || app
@@ -70,11 +92,18 @@ pub fn handle_lichess_menu_page_events(app: &mut App, key_event: KeyEvent) {
                         app.game.ui.prompt.message = "Enter your Lichess API token:".to_string();
                         return;
                     }
+                    if app.lichess_state.ongoing_games.is_empty() {
+                        app.ui_state.show_message_popup(
+                            "Loading your ongoing games ...".to_string(),
+                            Popups::Loading,
+                        );
+                    }
+
                     app.fetch_ongoing_games();
                     app.ui_state.current_page = Pages::OngoingGames;
                     app.ui_state.menu_cursor = 0;
                 }
-                3 => {
+                LichessMenuItems::JoinByCode => {
                     // Join by Code
                     if app.lichess_state.token.is_none()
                         || app
@@ -93,11 +122,10 @@ pub fn handle_lichess_menu_page_events(app: &mut App, key_event: KeyEvent) {
                     app.ui_state.current_popup = Some(Popups::EnterGameCode);
                     app.game.ui.prompt.reset();
                 }
-                4 => {
+                LichessMenuItems::Disconnect => {
                     // Disconnect
                     app.disconnect_lichess();
                 }
-                _ => {}
             }
         }
         KeyCode::Esc | KeyCode::Char('b') => {

--- a/src/handlers/popup.rs
+++ b/src/handlers/popup.rs
@@ -29,6 +29,7 @@ pub fn handle_popup_input(app: &mut App, key_event: KeyEvent, popup: Popups) {
         Popups::SeekingLichessGame => handle_seeking_lichess_game(app, key_event),
         Popups::ResignConfirmation => handle_resign_confirmation(app, key_event),
         Popups::MoveInputSelection => handle_move_input_selection(app, key_event),
+        _ => fallback_key_handler(app, key_event),
     }
 }
 
@@ -249,7 +250,7 @@ fn handle_seeking_lichess_game(app: &mut App, key_event: KeyEvent) {
             if let Some(token) = &app.lichess_state.cancellation_token {
                 token.store(true, std::sync::atomic::Ordering::Relaxed);
             }
-            app.lichess_state.seek_receiver = None;
+            app.lichess_state.receiver = None;
             app.lichess_state.cancellation_token = None;
             app.ui_state.close_popup();
             app.ui_state.current_page = Pages::Home;

--- a/src/lichess/models.rs
+++ b/src/lichess/models.rs
@@ -78,7 +78,7 @@ pub struct OngoingGame {
 pub struct OpponentInfo {
     pub id: Option<String>,
     pub username: String,
-    pub rating: Option<u32>,
+    pub rating: Option<u16>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -103,10 +103,10 @@ pub struct PuzzleGame {
 #[derive(Debug, Deserialize, Clone)]
 pub struct PuzzleInfo {
     pub id: String,
-    pub rating: u32,
+    pub rating: u16,
     pub plays: u32,
     #[serde(rename = "initialPly")]
-    pub initial_ply: u32,
+    pub initial_ply: u16,
     pub solution: Vec<String>,
     pub themes: Vec<String>,
 }
@@ -191,17 +191,17 @@ pub struct Perfs {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Perf {
-    pub rating: u32,
+    pub rating: u16,
     #[serde(default)]
-    pub rd: Option<u32>,
+    pub rd: Option<u16>,
     #[serde(default)]
-    pub prog: Option<i32>,
+    pub prog: Option<i16>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct RatingHistoryEntry {
     pub name: String,
-    pub points: Vec<[i32; 4]>, // [year, month, day, rating]
+    pub points: Vec<[i16; 4]>, // [year, month, day, rating]
 }
 
 #[derive(Clone)]

--- a/src/lichess/puzzle.rs
+++ b/src/lichess/puzzle.rs
@@ -42,15 +42,13 @@ impl LichessClient {
         Ok(puzzle)
     }
 
-    /// Submit puzzle result to Lichess
-    /// According to https://lichess.org/api#tag/puzzles/post/apipuzzlebatchangle
-    /// This endpoint expects a JSON body with puzzle results
+    /// Submit puzzle result to Lichess. Returns the rating diff from the response.
     pub fn submit_puzzle_result(
         &self,
         puzzle_id: &str,
         win: bool,
         time: Option<u32>,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<i32, Box<dyn Error>> {
         use serde_json::json;
 
         // The API expects a JSON object with a "solutions" field containing an array
@@ -104,6 +102,14 @@ impl LichessClient {
         }
 
         log::info!("✓ Puzzle result submitted successfully to Lichess!");
-        Ok(())
+
+        let body: serde_json::Value = serde_json::from_str(&response_text)?;
+        let rating_diff = body["rounds"]
+            .as_array()
+            .and_then(|r| r.first())
+            .and_then(|r| r["ratingDiff"].as_i64())
+            .unwrap_or(0) as i32;
+
+        Ok(rating_diff)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,8 +327,7 @@ fn main() -> AppResult<()> {
         if app.check_and_apply_bot_move() {
             app.check_and_show_game_end();
         }
-        // Check if Lichess seek is done
-        app.check_lichess_seek();
+        app.check_lichess_updates();
 
         // Check if game ended
         app.check_game_end_status();

--- a/src/state/lichess_state.rs
+++ b/src/state/lichess_state.rs
@@ -8,8 +8,9 @@ use shakmaty::Color;
 use std::sync::mpsc::Receiver;
 
 pub enum LichessUpdate {
-    ProfileLoaded(Result<Box<(UserProfile, Vec<RatingHistoryEntry>)>, String>),
+    ProfileResult(Result<Box<(UserProfile, Vec<RatingHistoryEntry>)>, String>),
     SeekResult(Result<(String, Color), String>),
+    OngoingGamesResult(Result<Vec<OngoingGame>, String>),
 }
 
 /// All Lichess-related runtime state held by [`crate::app::App`].

--- a/src/state/lichess_state.rs
+++ b/src/state/lichess_state.rs
@@ -7,6 +7,11 @@ use crate::{
 use shakmaty::Color;
 use std::sync::mpsc::Receiver;
 
+pub enum LichessUpdate {
+    ProfileLoaded(Result<(UserProfile, Vec<RatingHistoryEntry>), String>),
+    SeekResult(Result<(String, Color), String>),
+}
+
 /// All Lichess-related runtime state held by [`crate::app::App`].
 ///
 /// Keeps the API token and client together so that any method needing a
@@ -17,8 +22,8 @@ use std::sync::mpsc::Receiver;
 pub struct LichessState {
     /// Lichess API token
     pub token: Option<String>,
-    /// Lichess seek receiver
-    pub seek_receiver: Option<Receiver<Result<(String, Color), String>>>,
+    /// Background task receiver
+    pub receiver: Option<Receiver<LichessUpdate>>,
     /// Lichess cancellation token
     pub cancellation_token: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     /// Ongoing Lichess games

--- a/src/state/lichess_state.rs
+++ b/src/state/lichess_state.rs
@@ -8,7 +8,7 @@ use shakmaty::Color;
 use std::sync::mpsc::Receiver;
 
 pub enum LichessUpdate {
-    ProfileLoaded(Result<(UserProfile, Vec<RatingHistoryEntry>), String>),
+    ProfileLoaded(Result<Box<(UserProfile, Vec<RatingHistoryEntry>)>, String>),
     SeekResult(Result<(String, Color), String>),
 }
 

--- a/src/ui/main_ui.rs
+++ b/src/ui/main_ui.rs
@@ -25,6 +25,7 @@ use crate::{
                 game_code::render_enter_game_code_popup, puzzle_end::render_puzzle_end_popup,
                 token::render_enter_lichess_token_popup,
             },
+            loading::render_loading_popup,
             move_input::render_move_input_popup,
             multiplayer::{
                 enter_ip::render_enter_multiplayer_ip,
@@ -133,6 +134,14 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
             };
 
             render_puzzle_end_popup(frame, &message, elo_change, is_calculating);
+        }
+        Some(Popups::Loading) => {
+            let message = if let Some(ref msg) = app.ui_state.popup_message {
+                msg.clone()
+            } else {
+                "Loading ...".to_string()
+            };
+            render_loading_popup(frame, message);
         }
         _ => {}
     }

--- a/src/ui/menu/lichess_menu.rs
+++ b/src/ui/menu/lichess_menu.rs
@@ -136,7 +136,7 @@ fn render_menu_panel(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(menu, area);
 }
 
-fn rating_line(label: &str, rating: u32, prog: Option<i32>) -> Line<'static> {
+fn rating_line(label: &str, rating: u16, prog: Option<i16>) -> Line<'static> {
     let text = match prog {
         Some(p) if p > 0 => format!("{} (+{})", rating, p),
         Some(p) if p < 0 => format!("{} ({})", rating, p),

--- a/src/ui/menu/rating_chart.rs
+++ b/src/ui/menu/rating_chart.rs
@@ -89,8 +89,8 @@ pub(super) fn render_rating_history_chart(
 }
 
 /// Convert rating history point to days since epoch
-fn point_to_days(year: i32, month: i32, day: i32) -> Option<f64> {
-    NaiveDate::from_ymd_opt(year, (month + 1) as u32, day as u32)
+fn point_to_days(year: i16, month: i16, day: i16) -> Option<f64> {
+    NaiveDate::from_ymd_opt(year.into(), (month + 1) as u32, day as u32)
         .and_then(|date| date.and_hms_opt(0, 0, 0))
         .map(|datetime| {
             DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc).timestamp() as f64

--- a/src/ui/popup/loading.rs
+++ b/src/ui/popup/loading.rs
@@ -1,21 +1,18 @@
 //! Loading popup
 
-use crate::{constants::WHITE, ui::components::centered_rect::centered_rect};
+use crate::{
+    constants::{CHESS_SET, WHITE},
+    ui::components::centered_rect::centered_rect,
+};
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout},
     style::Style,
     widgets::{Block, BorderType, Borders, Clear, Padding},
 };
-use throbber_widgets_tui::Set;
 
 /// Renders a centered popup with a throbber chess spinner and a custom text message
 pub fn render_loading_popup(frame: &mut Frame, loading_text: String) {
-    let chess_set = Set {
-        full: "♚",
-        empty: " ",
-        symbols: &["♚", "♛", "♜", "♝", "♞", "♟", "♔", "♕", "♖", "♗", "♘", "♙"],
-    };
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
@@ -53,7 +50,7 @@ pub fn render_loading_popup(frame: &mut Frame, loading_text: String) {
                 .fg(ratatui::style::Color::Yellow)
                 .add_modifier(ratatui::style::Modifier::BOLD),
         )
-        .throbber_set(chess_set)
+        .throbber_set(CHESS_SET)
         .use_type(throbber_widgets_tui::WhichUse::Spin);
 
     frame.render_widget(Clear, area);

--- a/src/ui/popup/loading.rs
+++ b/src/ui/popup/loading.rs
@@ -1,0 +1,62 @@
+//! Loading popup
+
+use crate::{constants::WHITE, ui::components::centered_rect::centered_rect};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout},
+    style::Style,
+    widgets::{Block, BorderType, Borders, Clear, Padding},
+};
+use throbber_widgets_tui::Set;
+
+/// Renders a centered popup with a throbber chess spinner and a custom text message
+pub fn render_loading_popup(frame: &mut Frame, loading_text: String) {
+    let chess_set = Set {
+        full: "♚",
+        empty: " ",
+        symbols: &["♚", "♛", "♜", "♝", "♞", "♟", "♔", "♕", "♖", "♗", "♘", "♙"],
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
+        .border_style(Style::default().fg(WHITE));
+
+    let area = centered_rect(40, 40, frame.area());
+    let inner_area = block.inner(area);
+
+    // Chess pieces are double-width (2 cols) + space (1) + label
+    let content_width = loading_text.len() as u16 + 3;
+
+    let throbber_row = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(50),
+            Constraint::Length(1),
+            Constraint::Fill(1),
+        ])
+        .split(inner_area)[1];
+
+    let throbber_col = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Fill(1),
+            Constraint::Length(content_width),
+            Constraint::Fill(1),
+        ])
+        .split(throbber_row)[1];
+
+    let full = throbber_widgets_tui::Throbber::default()
+        .label(loading_text)
+        .throbber_style(
+            ratatui::style::Style::default()
+                .fg(ratatui::style::Color::Yellow)
+                .add_modifier(ratatui::style::Modifier::BOLD),
+        )
+        .throbber_set(chess_set)
+        .use_type(throbber_widgets_tui::WhichUse::Spin);
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(block, area);
+    frame.render_widget(full, throbber_col);
+}

--- a/src/ui/popup/mod.rs
+++ b/src/ui/popup/mod.rs
@@ -5,6 +5,7 @@ pub mod end;
 pub mod error;
 pub mod help;
 pub mod lichess;
+pub mod loading;
 pub mod move_input;
 pub mod multiplayer;
 pub mod pgn;

--- a/src/ui/popup/multiplayer/wait_for_player.rs
+++ b/src/ui/popup/multiplayer/wait_for_player.rs
@@ -1,12 +1,12 @@
 //! Waiting-for-opponent popup shown while the host listens for a connection.
 
 use crate::{
-    constants::{NETWORK_PORT, WHITE},
+    constants::{CHESS_SET, NETWORK_PORT, WHITE},
     ui::components::centered_rect::centered_rect,
 };
 use ratatui::{
     Frame,
-    layout::Alignment,
+    layout::{Alignment, Constraint, Direction, Layout},
     style::Style,
     text::Line,
     widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap},
@@ -16,12 +16,12 @@ use std::net::IpAddr;
 /// Renders a "Waiting for other player" popup displaying the host's IP and port.
 pub fn render_wait_for_other_player(frame: &mut Frame, ip: Option<IpAddr>) {
     let block = Block::default()
-        .title("Waiting ...")
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .padding(Padding::horizontal(1))
         .border_style(Style::default().fg(WHITE));
     let area = centered_rect(40, 40, frame.area());
+    let inner_area = block.inner(area);
 
     let ip_str = ip
         .map(|i| i.to_string())
@@ -30,7 +30,7 @@ pub fn render_wait_for_other_player(frame: &mut Frame, ip: Option<IpAddr>) {
     let text = vec![
         Line::from(""),
         Line::from(""),
-        Line::from("Waiting for other player").alignment(Alignment::Center),
+        Line::from("").alignment(Alignment::Center),
         Line::from(format!(
             "Host IP address and port: {}:{}",
             ip_str, NETWORK_PORT
@@ -43,7 +43,38 @@ pub fn render_wait_for_other_player(frame: &mut Frame, ip: Option<IpAddr>) {
         .alignment(Alignment::Left)
         .wrap(Wrap { trim: true });
 
-    frame.render_widget(Clear, area); //this clears out the background
+    let content_width = "Waiting for other player ...".len() as u16 + 3;
+
+    let throbber_row = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(45),
+            Constraint::Length(1),
+            Constraint::Fill(1),
+        ])
+        .split(inner_area)[1];
+
+    let throbber_col = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Fill(1),
+            Constraint::Length(content_width),
+            Constraint::Fill(1),
+        ])
+        .split(throbber_row)[1];
+
+    let full = throbber_widgets_tui::Throbber::default()
+        .label("Waiting for other player ...")
+        .throbber_style(
+            ratatui::style::Style::default()
+                .fg(ratatui::style::Color::Yellow)
+                .add_modifier(ratatui::style::Modifier::BOLD),
+        )
+        .throbber_set(CHESS_SET)
+        .use_type(throbber_widgets_tui::WhichUse::Spin);
+
+    frame.render_widget(Clear, area);
     frame.render_widget(block, area);
     frame.render_widget(paragraph, area);
+    frame.render_widget(full, throbber_col);
 }


### PR DESCRIPTION
# Loading popup

## Description

- Adding a loading popup to indicate something is happening while waiting.
- Add the loader on the multiplayer wait popup

Spinner using [throbber-widgets-tui](https://crates.io/crates/throbber-widgets-tui)

<img width="519" height="430" alt="Capture d’écran, le 2026-05-02 à 19 26 11" src="https://github.com/user-attachments/assets/5f2e2cfe-68d3-4f98-9054-093f4ff92bb7" />
In lichess

<img width="564" height="394" alt="Capture d’écran, le 2026-05-02 à 19 26 35" src="https://github.com/user-attachments/assets/c2cf8f6d-3f3b-4e51-923e-a6efc5b08609" />

In multiplayer hosting

Fixes #257 

## How Has This Been Tested?

Manual tests

## Additional updates

- Fetch user profile async
- Fetch ongoing games async
- Reduce the size of some types u32 -> u16 etc 
- Improve the receiver pattern for the lichess state with a proper enum
- Remove useless call in puzzle rating diff
- Proper enum for the lichess menu

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
