### PR TITLE
fix: auto convert color when env COLORTERM is not here

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,45 @@
+use std::sync::LazyLock;
+
+use ratatui::style::Color;
+use crate::constants::{BLACK, WHITE};
+
+static HAS_TRUE_COLOR: LazyLock<bool> = LazyLock::new(|| {
+    matches!(
+        std::env::var("COLORTERM").as_deref(),
+        Ok("truecolor") | Ok("24bit")
+    )
+});
+
+fn nearest_ansi256(r: u8, g: u8, b: u8) -> u8 {
+    if r == g && g == b {
+        if r < 8 { return 16; }
+        if r > 248 { return 231; }
+        return 232 + (r - 8) / 10;
+    }
+    let r6 = ((r as u16 * 5 + 127) / 255) as u8;
+    let g6 = ((g as u16 * 5 + 127) / 255) as u8;
+    let b6 = ((b as u16 * 5 + 127) / 255) as u8;
+    16 + 36 * r6 + 6 * g6 + b6
+}
+
+/// Convert `Color::Rgb` to nearest 256-color index when TrueColor is
+/// unavailable. Non-Rgb variants pass through unchanged.
+pub fn adapt_color(color: Color) -> Color {
+    if *HAS_TRUE_COLOR {
+        return color;
+    }
+    match color {
+        Color::Rgb(r, g, b) => Color::Indexed(nearest_ansi256(r, g, b)),
+        other => other,
+    }
+}
+
+/// Light board square color, adapted to terminal capability.
+pub fn board_white() -> Color {
+    adapt_color(WHITE)
+}
+
+/// Dark board square color, adapted to terminal capability.
+pub fn board_black() -> Color {
+    adapt_color(BLACK)
+}

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
-use ratatui::style::Color;
 use crate::constants::{BLACK, WHITE};
+use ratatui::style::Color;
 
 static HAS_TRUE_COLOR: LazyLock<bool> = LazyLock::new(|| {
     matches!(
@@ -12,8 +12,12 @@ static HAS_TRUE_COLOR: LazyLock<bool> = LazyLock::new(|| {
 
 fn nearest_ansi256(r: u8, g: u8, b: u8) -> u8 {
     if r == g && g == b {
-        if r < 8 { return 16; }
-        if r > 248 { return 231; }
+        if r < 8 {
+            return 16;
+        }
+        if r > 248 {
+            return 231;
+        }
         return 232 + (r - 8) / 10;
     }
     let r6 = ((r as u16 * 5 + 127) / 255) as u8;

--- a/src/game_logic/ui.rs
+++ b/src/game_logic/ui.rs
@@ -7,6 +7,7 @@ use super::{
     game::{Game, GameLogic},
 };
 use crate::{
+    color::{adapt_color, board_black, board_white},
     constants::{BLACK, DisplayMode, WHITE},
     game_logic::coord::MoveDirection,
     pieces::{PieceSize, role_to_utf_enum},
@@ -278,8 +279,8 @@ impl UI {
         let line_count = piece_str.lines().count().max(1) as u16;
 
         let color_enum = match piece_color {
-            Some(shakmaty::Color::White) => self.skin.piece_white_color,
-            Some(shakmaty::Color::Black) => self.skin.piece_black_color,
+            Some(shakmaty::Color::White) => adapt_color(self.skin.piece_white_color),
+            Some(shakmaty::Color::Black) => adapt_color(self.skin.piece_black_color),
             None => Color::Red,
         };
 
@@ -747,13 +748,13 @@ impl UI {
         // Color of the cell to draw the board
         let cell_color: Color = if (i + j).is_multiple_of(2) {
             match self.display_mode {
-                DisplayMode::CUSTOM => self.skin.board_white_color,
-                _ => WHITE,
+                DisplayMode::CUSTOM => adapt_color(self.skin.board_white_color),
+                _ => board_white(),
             }
         } else {
             match self.display_mode {
-                DisplayMode::CUSTOM => self.skin.board_black_color,
-                _ => BLACK,
+                DisplayMode::CUSTOM => adapt_color(self.skin.board_black_color),
+                _ => board_black(),
             }
         };
 
@@ -780,16 +781,16 @@ impl UI {
             let highlight_color = match self.display_mode {
                 DisplayMode::CUSTOM => {
                     if is_selected_cell {
-                        self.skin.selection_color
+                        adapt_color(self.skin.selection_color)
                     } else {
-                        self.skin.last_move_color
+                        adapt_color(self.skin.last_move_color)
                     }
                 }
                 _ => Color::LightGreen,
             };
             render_cell(frame, square, highlight_color, None);
         } else if is_cell_in_positions {
-            render_cell(frame, square, Color::Rgb(100, 100, 100), None);
+            render_cell(frame, square, adapt_color(Color::Rgb(100, 100, 100)), None);
             // else as a last resort we draw the cell with the default color either white or black
         } else {
             let mut cell = Block::default();
@@ -806,7 +807,7 @@ impl UI {
 
         if !self.hide_cursor && current_rendering_coord == self.cursor_coordinates {
             let cursor_color = match self.display_mode {
-                DisplayMode::CUSTOM => self.skin.cursor_color,
+                DisplayMode::CUSTOM => adapt_color(self.skin.cursor_color),
                 _ => Color::LightBlue,
             };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 #![warn(unreachable_pub)]
 
 pub mod animations;
-pub mod color;
 pub mod app;
+pub mod color;
 pub mod config;
 pub mod constants;
 pub mod event;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(unreachable_pub)]
 
 pub mod animations;
+pub mod color;
 pub mod app;
 pub mod config;
 pub mod constants;


### PR DESCRIPTION
# auto convert color when env COLORTERM is not here

## Description
TrueColor support via `$COLORTERM` at startup and converts any `Color::Rgb` to the nearest xterm-256 palette
<img width="1017" height="803" alt="Capture d’écran, le 2026-05-11 à 08 47 54" src="https://github.com/user-attachments/assets/fcd5622a-d6cb-4de1-94c4-5a816a897829" />

Fixes #275 

## How Has This Been Tested?

Manually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
