### PR TITLE
fix(multiplayer): fix UDP reachability check binding to remote IP

### DIFF
--- a/src/app/multiplayer.rs
+++ b/src/app/multiplayer.rs
@@ -43,8 +43,11 @@ impl App {
         log::info!("Attempting to connect to: {}", addr_with_port);
 
         // ping the server to see if it's up
-        if let Err(e) = UdpSocket::bind(addr_with_port.clone()) {
-            log::error!("Server is unreachable at {}: {}", addr_with_port, e);
+        let reachable = UdpSocket::bind("0.0.0.0:0")
+            .and_then(|s| s.connect(addr_with_port.clone()))
+            .is_ok();
+        if !reachable {
+            log::error!("Server is unreachable at {}", addr_with_port);
             self.multiplayer_state.host_ip = None;
             return;
         }


### PR DESCRIPTION
UdpSocket::bind(server_addr) tried to claim the server's IP as a local address, causing EADDRNOTAVAIL (errno 99) on any client that isn't the host. Fix by binding to an ephemeral local port and using connect() to verify the address is routable without sending traffic.


cargo check — confirmed the code compiles without errors or warnings (on linux at least)
