### PR TITLE
Set cursor coordinates properly after selecting a piece with a mouse when the board is flipped

### DIFF
--- a/src/handlers/handler.rs
+++ b/src/handlers/handler.rs
@@ -42,7 +42,8 @@ pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
         if let Some(selected_square) = app.game.ui.selected_square {
             // If a piece was selected via mouse, move cursor to that square
             app.game.ui.cursor_coordinates =
-                get_coord_from_square(selected_square, app.game.logic.game_board.is_flipped);
+                // Board flipping is already accounted for when selecting the square
+                get_coord_from_square(selected_square, false);
             app.game.ui.selected_square = None;
         } else {
             app.game.ui.cursor_coordinates = Coord::default();


### PR DESCRIPTION
# Set cursor coordinates properly after selecting a piece with a mouse when the board is flipped

## Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a bug where, when playing a two-player local game and it's black's turn to move, the cursor coordinates are set to the wrong position after selecting a piece using your mouse, rather than setting it to the position of the piece that was clicked.

## How Has This Been Tested?

Going into a local multiplayer game and seeing where the cursor position is set.

Original behavior:

https://github.com/user-attachments/assets/be72a29e-9f4e-4b51-9470-5b886d3b0a51

Expected behavior (after fix):

https://github.com/user-attachments/assets/5f0a4482-8d88-492e-ac92-8e5af564d2d1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
