### PR TITLE
feat: Created new settings menu on home page for all the game and app settings

### DIFF
--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -7,6 +7,7 @@ use crate::game_logic::game::Game;
 use crate::handlers::game_mode_menu::{
     AvailableGameMode, cycle_difficulty_next, cycle_difficulty_prev,
 };
+use crate::sound::play_menu_nav_sound;
 /// Typed representation of the main-menu entries, indexed by `menu_cursor`.
 pub enum MainMenuItems {
     GameModeMenu,
@@ -85,7 +86,7 @@ impl App {
         let future_skin = self.theme_state.get_skin(next);
         let future_skin_name = future_skin.clone().name;
 
-        crate::sound::play_menu_nav_sound(); // move
+        play_menu_nav_sound(); // move
 
         // Update selected skin name and apply it
         self.theme_state.loaded_skin = Some(future_skin.clone());
@@ -111,7 +112,7 @@ impl App {
             cycle_difficulty_prev(self);
         }
 
-        crate::sound::play_menu_nav_sound(); // move
+        play_menu_nav_sound(); // move
     }
 
     /// Resets the application state and returns to the home page.

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -1,38 +1,27 @@
 //! Menu navigation and skin cycling.
 
 use crate::app::App;
-use crate::constants::{DEFAULT_CUSTOM_TIME_VALUE, DEFAULT_TIME_CONTROL_SELECTED};
-use crate::constants::{DisplayMode, Pages, Popups};
+use crate::constants::{DEFAULT_CUSTOM_TIME_VALUE, DEFAULT_TIME_CONTROL_SELECTED, DisplayMode};
+use crate::constants::{Pages, Popups};
 use crate::game_logic::game::Game;
-use crate::handlers::game_mode_menu::AvailableGameMode;
-use crate::sound::play_menu_nav_sound;
+use crate::handlers::game_mode_menu::{
+    AvailableGameMode, cycle_difficulty_next, cycle_difficulty_prev,
+};
 /// Typed representation of the main-menu entries, indexed by `menu_cursor`.
 pub enum MainMenuItems {
     GameModeMenu,
     LichessMenu,
-    SkinSelector,
-    SoundSelector,
+    SettingsMenu,
     Help,
     Credit,
 }
 
 impl From<u8> for MainMenuItems {
     fn from(value: u8) -> Self {
-        #[cfg(feature = "sound")]
         match value {
             0 => MainMenuItems::GameModeMenu,
             1 => MainMenuItems::LichessMenu,
-            2 => MainMenuItems::SkinSelector,
-            3 => MainMenuItems::SoundSelector,
-            4 => MainMenuItems::Help,
-            5 => MainMenuItems::Credit,
-            _ => MainMenuItems::GameModeMenu,
-        }
-        #[cfg(not(feature = "sound"))]
-        match value {
-            0 => MainMenuItems::GameModeMenu,
-            1 => MainMenuItems::LichessMenu,
-            2 => MainMenuItems::SkinSelector,
+            2 => MainMenuItems::SettingsMenu,
             3 => MainMenuItems::Help,
             4 => MainMenuItems::Credit,
             _ => MainMenuItems::GameModeMenu,
@@ -79,30 +68,13 @@ impl App {
                 }
                 self.fetch_lichess_user_profile();
             }
-            MainMenuItems::SkinSelector => {
-                // Cycle through available skins
-                self.cycle_skin(true);
-                self.update_config_from_app();
+            MainMenuItems::SettingsMenu => {
+                // Settings Menu
+                // Reset everything to ensure cursor starts at first item
+                self.ui_state.menu_cursor = 0;
+                self.ui_state.current_page = Pages::SettingsMenu;
             }
-            #[cfg(feature = "sound")]
-            MainMenuItems::SoundSelector => {
-                // Toggle sound
-
-                use crate::sound::set_sound_enabled;
-
-                self.sound_enabled = !self.sound_enabled;
-                set_sound_enabled(self.sound_enabled);
-                self.update_config_from_app();
-            }
-            #[cfg(feature = "sound")]
             MainMenuItems::Help => self.ui_state.toggle_help_popup(),
-            #[cfg(feature = "sound")]
-            MainMenuItems::Credit => self.ui_state.current_page = Pages::Credit,
-            #[cfg(not(feature = "sound"))]
-            MainMenuItems::SoundSelector => {}
-            #[cfg(not(feature = "sound"))]
-            MainMenuItems::Help => self.ui_state.toggle_help_popup(),
-            #[cfg(not(feature = "sound"))]
             MainMenuItems::Credit => self.ui_state.current_page = Pages::Credit,
         }
     }
@@ -113,7 +85,7 @@ impl App {
         let future_skin = self.theme_state.get_skin(next);
         let future_skin_name = future_skin.clone().name;
 
-        play_menu_nav_sound(); // move
+        crate::sound::play_menu_nav_sound(); // move
 
         // Update selected skin name and apply it
         self.theme_state.loaded_skin = Some(future_skin.clone());
@@ -121,11 +93,25 @@ impl App {
         self.game.ui.skin = future_skin;
 
         // Set display mode based on skin name
-        match future_skin_name.as_str() {
-            "Default" => self.game.ui.display_mode = DisplayMode::DEFAULT,
-            "ASCII" => self.game.ui.display_mode = DisplayMode::ASCII,
-            _ => self.game.ui.display_mode = DisplayMode::CUSTOM,
+        let display_mode = match future_skin_name.as_str() {
+            "Default" => DisplayMode::DEFAULT,
+            "ASCII" => DisplayMode::ASCII,
+            _ => DisplayMode::CUSTOM,
+        };
+
+        self.game.ui.display_mode = display_mode;
+    }
+
+    /// Cycles to the next or previous bot difficulty level.
+    /// Pass `true` to advance forward, `false` to go back.
+    pub fn cycle_bot_difficulty(&mut self, next: bool) {
+        if next {
+            cycle_difficulty_next(self);
+        } else {
+            cycle_difficulty_prev(self);
         }
+
+        crate::sound::play_menu_nav_sound(); // move
     }
 
     /// Resets the application state and returns to the home page.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -139,6 +139,8 @@ pub enum Pages {
     GameModeMenu,
     /// PGN replay viewer.
     PgnViewer,
+    /// Settings menu.
+    SettingsMenu,
 }
 impl Pages {
     #[must_use]
@@ -180,6 +182,8 @@ pub enum Popups {
     LoadPgnPath,
     /// Spinner to make user wait
     Loading,
+    /// Text input for chess engine path.
+    EnterEnginePath,
 }
 
 /// Base URL for all Lichess REST API requests.

--- a/src/handlers/game_mode_menu.rs
+++ b/src/handlers/game_mode_menu.rs
@@ -372,7 +372,7 @@ fn handle_menu_navigation(app: &mut App, key_event: KeyEvent, game_mode: Availab
     }
 }
 
-fn cycle_difficulty_prev(app: &mut App) {
+pub fn cycle_difficulty_prev(app: &mut App) {
     match app.bot_state.bot_difficulty {
         None => app.bot_state.bot_difficulty = Some((BOT_DIFFICULTY_COUNT - 1) as u8),
         Some(0) => app.bot_state.bot_difficulty = None,
@@ -381,7 +381,7 @@ fn cycle_difficulty_prev(app: &mut App) {
     app.update_config_from_app();
 }
 
-fn cycle_difficulty_next(app: &mut App) {
+pub fn cycle_difficulty_next(app: &mut App) {
     match app.bot_state.bot_difficulty {
         None => app.bot_state.bot_difficulty = Some(0),
         Some(i) if i + 1 >= BOT_DIFFICULTY_COUNT as u8 => app.bot_state.bot_difficulty = None,

--- a/src/handlers/handler.rs
+++ b/src/handlers/handler.rs
@@ -12,6 +12,7 @@ use crate::handlers::lichess::ongoing_games::handle_ongoing_games_page_events;
 use crate::handlers::multiplayer::handle_multiplayer_page_events;
 use crate::handlers::pgn::handle_pgn_viewer_events;
 use crate::handlers::popup::handle_popup_input;
+use crate::handlers::settings_menu::handle_settings_menu_page_events;
 use crate::handlers::solo::handle_solo_page_events;
 use crate::utils::{flip_square_if_needed, get_coord_from_square};
 use crate::{
@@ -74,6 +75,7 @@ pub fn handle_page_input(app: &mut App, key_event: KeyEvent) {
         Pages::Bot => handle_bot_page_events(app, key_event),
         Pages::Credit => handle_credit_page_events(app, key_event),
         Pages::PgnViewer => handle_pgn_viewer_events(app, key_event),
+        Pages::SettingsMenu => handle_settings_menu_page_events(app, key_event),
     }
 }
 

--- a/src/handlers/home.rs
+++ b/src/handlers/home.rs
@@ -8,28 +8,12 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent};
 pub fn handle_home_page_events(app: &mut App, key_event: KeyEvent) {
     // Number of menu items depends on whether sound feature is enabled
     const MENU_ITEMS: u8 = {
-        #[cfg(feature = "sound")]
-        {
-            6 // Play Game, Lichess, Skin, Sound, Help, About
-        }
-        #[cfg(not(feature = "sound"))]
-        {
-            5 // Play Game, Lichess, Skin, Help, About
-        }
+        5 // Play Game, Lichess, Settings, Help, About
     };
 
     match key_event.code {
         KeyCode::Up | KeyCode::Char('k') => app.ui_state.menu_cursor_up(MENU_ITEMS),
         KeyCode::Down | KeyCode::Char('j') => app.ui_state.menu_cursor_down(MENU_ITEMS),
-        // If on skin selection menu item (index 2), use left/right to cycle skins
-        KeyCode::Left | KeyCode::Char('h') if app.ui_state.menu_cursor == 2 => {
-            app.cycle_skin(false);
-            app.update_config_from_app();
-        }
-        KeyCode::Right | KeyCode::Char('l') if app.ui_state.menu_cursor == 2 => {
-            app.cycle_skin(true);
-            app.update_config_from_app();
-        }
         KeyCode::Char(' ') | KeyCode::Enter => app.menu_select(),
         KeyCode::Char('?') => app.ui_state.toggle_help_popup(),
         _ => fallback_key_handler(app, key_event),

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -9,4 +9,5 @@ pub mod lichess;
 pub mod multiplayer;
 pub mod pgn;
 pub mod popup;
+pub mod settings_menu;
 pub mod solo;

--- a/src/handlers/popup.rs
+++ b/src/handlers/popup.rs
@@ -29,6 +29,7 @@ pub fn handle_popup_input(app: &mut App, key_event: KeyEvent, popup: Popups) {
         Popups::SeekingLichessGame => handle_seeking_lichess_game(app, key_event),
         Popups::ResignConfirmation => handle_resign_confirmation(app, key_event),
         Popups::MoveInputSelection => handle_move_input_selection(app, key_event),
+        Popups::EnterEnginePath => handle_enter_engine_path(app, key_event),
         _ => fallback_key_handler(app, key_event),
     }
 }
@@ -308,6 +309,33 @@ fn handle_move_input_selection(app: &mut App, key_event: KeyEvent) {
             app.game
                 .apply_player_move(from, chess_move.to(), chess_move.promotion());
             app.game.ui.prompt.reset();
+        }
+        KeyCode::Char(to_insert) => app.game.ui.prompt.enter_char(to_insert),
+        KeyCode::Backspace => app.game.ui.prompt.delete_char(),
+        KeyCode::Left => app.game.ui.prompt.move_cursor_left(),
+        KeyCode::Right => app.game.ui.prompt.move_cursor_right(),
+        KeyCode::Esc => app.ui_state.close_popup(),
+        _ => fallback_key_handler(app, key_event),
+    }
+}
+
+fn handle_enter_engine_path(app: &mut App, key_event: KeyEvent) {
+    match key_event.code {
+        KeyCode::Enter => {
+            app.game.ui.prompt.submit_message();
+            // Remove leading and trailing space, then remove leading and trailing single or double quote
+            let path = app
+                .game
+                .ui
+                .prompt
+                .message
+                .clone()
+                .trim()
+                .trim_matches(&['\'', '"'][..])
+                .to_string();
+
+            app.bot_state.chess_engine_path = Some(path);
+            app.ui_state.close_popup();
         }
         KeyCode::Char(to_insert) => app.game.ui.prompt.enter_char(to_insert),
         KeyCode::Backspace => app.game.ui.prompt.delete_char(),

--- a/src/handlers/settings_menu.rs
+++ b/src/handlers/settings_menu.rs
@@ -1,0 +1,147 @@
+//! Menu navigation and form filling for settings menu.
+
+use crate::{
+    app::App,
+    constants::{Pages, Popups},
+    handlers::handler::fallback_key_handler,
+};
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+
+/// Settings available from the selection menu.
+#[derive(PartialEq, Clone, Copy)]
+pub enum SettingsMenuItems {
+    SkinSelector,
+    SoundSelector,
+    AnimationsSelector,
+    ChessEnginePath,
+    BotDepth,
+    BotDifficulty,
+}
+
+impl From<u8> for SettingsMenuItems {
+    fn from(value: u8) -> Self {
+        #[cfg(feature = "sound")]
+        match value {
+            0 => SettingsMenuItems::SkinSelector,
+            1 => SettingsMenuItems::SoundSelector,
+            2 => SettingsMenuItems::AnimationsSelector,
+            3 => SettingsMenuItems::ChessEnginePath,
+            4 => SettingsMenuItems::BotDepth,
+            _ => SettingsMenuItems::BotDifficulty,
+        }
+        #[cfg(not(feature = "sound"))]
+        match value {
+            0 => SettingsMenuItems::SkinSelector,
+            1 => SettingsMenuItems::AnimationsSelector,
+            2 => SettingsMenuItems::ChessEnginePath,
+            3 => SettingsMenuItems::BotDepth,
+            _ => SettingsMenuItems::BotDifficulty,
+        }
+    }
+}
+
+impl SettingsMenuItems {
+    #[cfg(feature = "sound")]
+    pub const COUNT: u8 = 6;
+    #[cfg(not(feature = "sound"))]
+    pub const COUNT: u8 = 5;
+}
+
+/// Handles keyboard input on the Settings menu page.
+pub fn handle_settings_menu_page_events(app: &mut App, key_event: KeyEvent) {
+    if app.ui_state.menu_cursor > SettingsMenuItems::COUNT {
+        app.ui_state.menu_cursor = 0;
+    }
+
+    handle_menu_events(app, key_event);
+}
+
+// TODO: instead of calling `update_config_from_app()` on every event, it can be deferred to when menu closes
+fn handle_menu_events(app: &mut App, key_event: KeyEvent) {
+    let field: SettingsMenuItems = SettingsMenuItems::from(app.ui_state.menu_cursor);
+
+    match key_event.code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.ui_state.menu_cursor_up(SettingsMenuItems::COUNT);
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            app.ui_state.menu_cursor_down(SettingsMenuItems::COUNT);
+        }
+        // If on skin or bot difficulty selection menu item, use left/right to cycle options
+        KeyCode::Left | KeyCode::Char('h') => {
+            if field == SettingsMenuItems::SkinSelector {
+                app.cycle_skin(false);
+                app.update_config_from_app();
+            } else if field == SettingsMenuItems::BotDepth {
+                if app.bot_state.bot_depth > 1 {
+                    app.bot_state.bot_depth -= 1;
+                    app.update_config_from_app();
+                }
+            } else if field == SettingsMenuItems::BotDifficulty {
+                app.cycle_bot_difficulty(false);
+                app.update_config_from_app();
+            }
+        }
+        KeyCode::Right | KeyCode::Char('l') => {
+            if field == SettingsMenuItems::SkinSelector {
+                app.cycle_skin(true);
+                app.update_config_from_app();
+            } else if field == SettingsMenuItems::BotDepth {
+                if app.bot_state.bot_depth < 20 {
+                    app.bot_state.bot_depth += 1;
+                    app.update_config_from_app();
+                }
+            } else if field == SettingsMenuItems::BotDifficulty {
+                app.cycle_bot_difficulty(true);
+                app.update_config_from_app();
+            }
+        }
+        KeyCode::Char('s' | 'S') => {
+            app.cycle_skin(true);
+            app.update_config_from_app();
+        }
+        KeyCode::Char(' ') | KeyCode::Enter => {
+            match field {
+                SettingsMenuItems::SkinSelector => {
+                    // Cycle through available skins
+                    app.cycle_skin(true);
+                    app.update_config_from_app();
+                }
+                #[cfg(feature = "sound")]
+                SettingsMenuItems::SoundSelector => {
+                    // Toggle sound
+                    app.sound_enabled = !app.sound_enabled;
+                    crate::sound::set_sound_enabled(app.sound_enabled);
+                    app.update_config_from_app();
+                }
+                #[cfg(not(feature = "sound"))]
+                SettingsMenuItems::SoundSelector => {}
+                SettingsMenuItems::AnimationsSelector => {
+                    // Toggle animations
+                    app.animations_enabled = !app.animations_enabled;
+                    app.update_config_from_app();
+                }
+                SettingsMenuItems::ChessEnginePath => {
+                    app.ui_state.current_popup = Some(Popups::EnterEnginePath);
+                    app.game.ui.prompt.input =
+                        app.bot_state.chess_engine_path.clone().unwrap_or_default();
+                    app.game.ui.prompt.character_index = app.game.ui.prompt.input.chars().count();
+                }
+                SettingsMenuItems::BotDepth => {
+                    // Ignore
+                }
+                SettingsMenuItems::BotDifficulty => {
+                    // Cycle through available difficulty levels
+                    app.cycle_bot_difficulty(true);
+                    app.update_config_from_app();
+                }
+            }
+        }
+        KeyCode::Esc | KeyCode::Char('b') => {
+            app.ui_state.menu_cursor = 0;
+            app.ui_state.current_page = Pages::Home;
+        }
+        KeyCode::Char('?') => app.ui_state.toggle_help_popup(),
+        _ => fallback_key_handler(app, key_event),
+    }
+}

--- a/src/ui/main_ui.rs
+++ b/src/ui/main_ui.rs
@@ -15,10 +15,11 @@ use crate::{
         game_ui::render_game_ui,
         menu::{
             game_mode_menu::render_game_mode_menu, lichess_menu::render_lichess_menu,
-            main_menu::render_menu_ui,
+            main_menu::render_menu_ui, settings_menu::render_settings_menu,
         },
         popup::{
             credits::render_credit_popup,
+            engine_path::render_enter_engine_path_popup,
             error::render_error_popup,
             help::render_help_popup,
             lichess::{
@@ -63,6 +64,7 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
         Pages::GameModeMenu => render_game_mode_menu(frame, app),
         Pages::OngoingGames => render_ongoing_games(frame, app),
         Pages::PgnViewer => render_pgn_viewer(frame, app),
+        Pages::SettingsMenu => render_settings_menu(frame, app),
         Pages::Home | Pages::Credit => render_menu_ui(frame, app, main_area),
     }
 
@@ -144,6 +146,9 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
                 "Loading ...".to_string()
             };
             render_loading_popup(frame, message);
+        }
+        Some(Popups::EnterEnginePath) => {
+            render_enter_engine_path_popup(frame, &app.game.ui.prompt);
         }
         _ => {}
     }

--- a/src/ui/menu/main_menu.rs
+++ b/src/ui/menu/main_menu.rs
@@ -1,9 +1,6 @@
 //! Renders the title banner, navigation menu, skin indicator, and keyboard hints.
 
-use crate::{
-    app::App,
-    constants::{DisplayMode, TITLE},
-};
+use crate::{app::App, constants::TITLE};
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -14,44 +11,14 @@ use ratatui::{
 
 /// Renders the home menu with navigation options, skin selector, and title banner.
 pub fn render_menu_ui(frame: &mut Frame, app: &App, main_area: Rect) {
-    // Determine the "skin" text
-    let display_mode_menu = {
-        let skin_name = match app.game.ui.display_mode {
-            DisplayMode::DEFAULT => "Default",
-            DisplayMode::ASCII => "ASCII",
-            DisplayMode::CUSTOM => app.game.ui.skin.name.as_str(),
-        };
-        format!("Skin: {skin_name}")
-    };
-
-    // Determine the "sound" text (only if sound feature is enabled)
-    #[cfg(feature = "sound")]
-    let sound_menu = {
-        let sound_status = if app.sound_enabled {
-            "On 🔊"
-        } else {
-            "Off 🔇"
-        };
-        format!("Sound: {sound_status}")
-    };
-
     // Menu items with descriptions
-    let mut menu_items: Vec<(&str, &str)> = vec![
+    let menu_items: Vec<(&str, &str)> = vec![
         ("Play Game", "Local, Multiplayer, or Bot game"),
         ("Play on Lichess", "Play on Lichess.org"),
-        (&display_mode_menu, "Change display theme"),
-    ];
-
-    // Add sound menu item only if sound feature is enabled
-    #[cfg(feature = "sound")]
-    {
-        menu_items.push((&sound_menu, "Toggle sound effects"));
-    }
-
-    menu_items.extend(vec![
+        ("Settings", "View and change settings"),
         ("Help", "View keyboard shortcuts and controls"),
         ("About", "Project information and credits"),
-    ]);
+    ];
 
     // Menu height depends on number of items, each takes 3 lines (item + description/empty + spacing), plus padding
     let menu_height = menu_items.len() as u16 * 3 + 4;

--- a/src/ui/menu/mod.rs
+++ b/src/ui/menu/mod.rs
@@ -4,3 +4,4 @@ pub mod game_mode_menu;
 pub mod lichess_menu;
 pub mod main_menu;
 mod rating_chart;
+pub mod settings_menu;

--- a/src/ui/menu/settings_menu.rs
+++ b/src/ui/menu/settings_menu.rs
@@ -1,0 +1,158 @@
+//! Renders settings menu.
+
+use crate::{app::App, constants::DisplayMode};
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Paragraph},
+};
+
+pub fn render_settings_menu(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+
+    // Create main layout: title, content (menu), footer
+    let main_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Title
+            Constraint::Min(10),   // Content
+            Constraint::Length(3), // Footer
+        ])
+        .split(area);
+
+    // Title
+    let title = Paragraph::new("Settings")
+        .style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )
+        .alignment(Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded),
+        );
+    frame.render_widget(title, main_chunks[0]);
+
+    // Menu options
+    // Determine the "Skin" text
+    let display_mode_menu = {
+        let skin_name = match app.game.ui.display_mode {
+            DisplayMode::DEFAULT => "Default",
+            DisplayMode::ASCII => "ASCII",
+            DisplayMode::CUSTOM => app.game.ui.skin.name.as_str(),
+        };
+        format!("Skin: {skin_name}")
+    };
+
+    // Determine the "Sound" text (only if sound feature is enabled)
+    #[cfg(feature = "sound")]
+    let sound_menu = {
+        let sound_status = if app.sound_enabled {
+            "On 🔊"
+        } else {
+            "Off 🔇"
+        };
+        format!("Sound: {sound_status}")
+    };
+
+    // Determine the "Animations" text
+    let animations_menu = {
+        let animation_status = if app.animations_enabled { "On" } else { "Off" };
+        format!("Animations: {animation_status}")
+    };
+
+    // Determine the "Chess Engine Path" text
+    let chess_engine_path_menu = "Chess Engine Path".to_string();
+
+    // Determine the "Bot Depth" text
+    let bot_depth_menu = format!("Bot Depth: -  {}  +", app.bot_state.bot_depth);
+
+    // Determine the "Bot Difficulty" text
+    let bot_difficulty_menu = {
+        let difficulty = match app.bot_state.bot_difficulty {
+            Some(0) => "Easy",
+            Some(1) => "Medium",
+            Some(2) => "Hard",
+            Some(3) => "Magnus",
+            _ => "Off",
+        };
+        format!("Bot Difficulty: {difficulty}")
+    };
+
+    // Menu items with descriptions
+    let mut menu_items: Vec<(&str, &str)> = vec![(&display_mode_menu, "Change display theme")];
+
+    // Add sound menu item only if sound feature is enabled
+    #[cfg(feature = "sound")]
+    {
+        menu_items.push((&sound_menu, "Toggle sound effects"));
+    }
+
+    menu_items.push((&animations_menu, "Toggle animation effects"));
+    menu_items.push((
+        &chess_engine_path_menu,
+        "Set engine path with command-line arguments",
+    ));
+    menu_items.push((&bot_depth_menu, "Set bot thinking depth for chess engine"));
+    menu_items.push((&bot_difficulty_menu, "Set bot difficulty for chess engine"));
+
+    let mut menu_lines = vec![Line::from("")];
+
+    for (idx, (option, description)) in menu_items.iter().enumerate() {
+        let is_selected = app.ui_state.menu_cursor == idx as u8;
+
+        let style = if is_selected {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::White)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        let prefix = if is_selected { "► " } else { "  " };
+
+        menu_lines.push(Line::from(vec![
+            Span::styled(prefix, style),
+            Span::styled(*option, style),
+        ]));
+
+        menu_lines.push(Line::from(vec![
+            Span::raw("    "),
+            Span::styled(*description, Style::default().fg(Color::Gray)),
+        ]));
+
+        menu_lines.push(Line::from(""));
+    }
+
+    let menu = Paragraph::new(menu_lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .title(""),
+        )
+        .alignment(Alignment::Center);
+    frame.render_widget(menu, main_chunks[1]);
+
+    // Footer with controls
+    let footer = Paragraph::new(vec![Line::from(vec![
+        Span::styled("↑/↓", Style::default().fg(Color::Cyan)),
+        Span::raw(" Navigate  "),
+        Span::styled("Enter", Style::default().fg(Color::Cyan)),
+        Span::raw(" Select  "),
+        Span::styled("Esc", Style::default().fg(Color::Cyan)),
+        Span::raw(" Back to Home"),
+    ])])
+    .alignment(Alignment::Center)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded),
+    );
+    frame.render_widget(footer, main_chunks[2]);
+}

--- a/src/ui/popup/engine_path.rs
+++ b/src/ui/popup/engine_path.rs
@@ -1,0 +1,50 @@
+//! Chess engine path entry popup.
+
+use crate::ui::prompt::Prompt;
+use crate::{constants::WHITE, ui::components::centered_rect::centered_rect};
+use ratatui::{
+    Frame,
+    layout::{Alignment, Position},
+    style::Style,
+    text::Line,
+    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap},
+};
+
+/// Renders a text input for entering and saving a chess engine path.
+pub fn render_enter_engine_path_popup(frame: &mut Frame, prompt: &Prompt) {
+    let block = Block::default()
+        .title("Enter Chess Engine Path")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
+        .border_style(Style::default().fg(WHITE));
+    let area = centered_rect(70, 20, frame.area());
+
+    let current_input = prompt.input.as_str();
+
+    let text = vec![
+        Line::from("Enter the absolute path of chess engine:").alignment(Alignment::Center),
+        Line::from(""),
+        Line::from(current_input),
+        Line::from(""),
+        Line::from(""),
+        Line::from("Press `Enter` to save, `Esc` to cancel.").alignment(Alignment::Center),
+    ];
+
+    let paragraph = Paragraph::new(text)
+        .block(block.clone())
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: true });
+
+    frame.set_cursor_position(Position::new(
+        // Draw the cursor at the current position in the input field.
+        // This position is can be controlled via the left and right arrow key
+        area.x + prompt.character_index as u16 + 2,
+        // Move one line down, from the border to the input line
+        area.y + 3,
+    ));
+
+    frame.render_widget(Clear, area); //this clears out the background
+    frame.render_widget(block, area);
+    frame.render_widget(paragraph, area);
+}

--- a/src/ui/popup/mod.rs
+++ b/src/ui/popup/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod credits;
 pub mod end;
+pub mod engine_path;
 pub mod error;
 pub mod help;
 pub mod lichess;

--- a/tests/settings_menu_tests.rs
+++ b/tests/settings_menu_tests.rs
@@ -1,0 +1,138 @@
+use chess_tui::{
+    app::{App, AppResult},
+    constants::{Pages, Popups},
+    handlers::handler::handle_key_events,
+};
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent {
+        code,
+        modifiers: KeyModifiers::empty(),
+        kind: KeyEventKind::Press,
+        state: ratatui::crossterm::event::KeyEventState::empty(),
+    }
+}
+
+fn send(app: &mut App, keys: &[KeyCode]) -> AppResult<()> {
+    for &k in keys {
+        handle_key_events(key(k), app)?;
+    }
+    Ok(())
+}
+
+fn open_settings_menu() -> AppResult<App> {
+    let mut app = App::default();
+    send(&mut app, &[KeyCode::Down, KeyCode::Down, KeyCode::Enter])?;
+    Ok(app)
+}
+
+#[test]
+fn open_close_settings_menu() -> AppResult<()> {
+    let mut app = open_settings_menu()?;
+    assert_eq!(app.ui_state.current_page, Pages::SettingsMenu);
+
+    send(&mut app, &[KeyCode::Esc])?;
+    assert_eq!(app.ui_state.current_page, Pages::Home);
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "sound")]
+fn toggle_sound() -> AppResult<()> {
+    let mut app = open_settings_menu()?;
+    assert_eq!(app.ui_state.current_page, Pages::SettingsMenu);
+
+    let original_sound_status = app.sound_enabled;
+    send(&mut app, &[KeyCode::Down, KeyCode::Enter])?;
+    let new_sound_status = app.sound_enabled;
+    assert_ne!(new_sound_status, original_sound_status);
+
+    send(&mut app, &[KeyCode::Enter])?;
+    assert_eq!(original_sound_status, app.sound_enabled);
+
+    Ok(())
+}
+
+#[test]
+fn toggle_animations() -> AppResult<()> {
+    let mut app = open_settings_menu()?;
+    assert_eq!(app.ui_state.current_page, Pages::SettingsMenu);
+
+    let original_anim_status = app.animations_enabled;
+    send(
+        &mut app,
+        &[
+            KeyCode::Down,
+            #[cfg(feature = "sound")]
+            KeyCode::Down,
+            KeyCode::Enter,
+        ],
+    )?;
+    let new_anim_status = app.animations_enabled;
+    assert_ne!(new_anim_status, original_anim_status);
+
+    send(&mut app, &[KeyCode::Enter])?;
+    assert_eq!(original_anim_status, app.animations_enabled);
+
+    Ok(())
+}
+
+#[test]
+fn open_close_chess_engine_path_popup() -> AppResult<()> {
+    let mut app = open_settings_menu()?;
+    assert_eq!(app.ui_state.current_page, Pages::SettingsMenu);
+
+    send(
+        &mut app,
+        &[
+            KeyCode::Down,
+            KeyCode::Down,
+            #[cfg(feature = "sound")]
+            KeyCode::Down,
+            KeyCode::Enter,
+        ],
+    )?;
+    assert_eq!(app.ui_state.current_popup, Some(Popups::EnterEnginePath));
+
+    send(&mut app, &[KeyCode::Esc])?;
+    assert_eq!(app.ui_state.current_popup, None);
+    assert_eq!(app.ui_state.current_page, Pages::SettingsMenu);
+
+    Ok(())
+}
+
+#[test]
+fn change_bot_difficulty() -> AppResult<()> {
+    let mut app = open_settings_menu()?;
+    assert_eq!(app.ui_state.current_page, Pages::SettingsMenu);
+
+    let original_difficulty = app.bot_state.bot_difficulty;
+    send(
+        &mut app,
+        &[
+            KeyCode::Down,
+            KeyCode::Down,
+            KeyCode::Down,
+            #[cfg(feature = "sound")]
+            KeyCode::Down,
+            KeyCode::Down,
+            KeyCode::Right,
+        ],
+    )?;
+    let next_difficulty = app.bot_state.bot_difficulty;
+    assert_ne!(next_difficulty, original_difficulty);
+
+    send(&mut app, &[KeyCode::Left])?;
+    assert_eq!(app.bot_state.bot_difficulty, original_difficulty);
+
+    send(&mut app, &[KeyCode::Left])?;
+    let prev_difficulty = app.bot_state.bot_difficulty;
+    assert_ne!(prev_difficulty, original_difficulty);
+    assert_ne!(prev_difficulty, next_difficulty);
+
+    send(&mut app, &[KeyCode::Right])?;
+    assert_eq!(app.bot_state.bot_difficulty, original_difficulty);
+
+    Ok(())
+}


### PR DESCRIPTION
# Title

Implemented Settings menu (enhancement #269)

## Description

- Created new settings menu page which is accessible from home page.
- Moved existing `Skins` and `Sound` options and functionality from home page to settings page.
- Added new options for `Animations`, `Chess Engine Path`, `Bot Depth`, and `Bot Difficulty`.
- `Chess Engine Path` option prompts a new popup where engine path can be entered.
- Behavior of `Bot Depth` and `Bot Difficulty` options are similar to existing ones (from Game Mode Configuration).

Fixes # (issue)

## How Has This Been Tested?

- Created new integration tests `settings_menu_tests`.
- Done manual testing and verified expected behavior.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
