### PR TITLE
feat(lichess): support self-hosted Lichess instances

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -2,7 +2,7 @@
 
 use crate::app::App;
 use crate::config::Config;
-use crate::constants::config_dir;
+use crate::constants::{config_dir, lichess_api_url};
 use std::fs::{self, File};
 use std::io::Write;
 
@@ -27,6 +27,7 @@ impl App {
         config.bot_difficulty = self.bot_state.bot_difficulty;
         config.selected_skin_name = Some(self.theme_state.selected_skin_name.clone());
         config.lichess_token = self.lichess_state.token.clone();
+        config.lichess_api_url = Some(lichess_api_url());
         config.sound_enabled = Some(self.sound_enabled);
         config.animations_enabled = Some(self.animations_enabled);
 

--- a/src/app/lichess.rs
+++ b/src/app/lichess.rs
@@ -1,7 +1,9 @@
 //! Lichess authentication, game streaming, and puzzle management.
 
 use crate::app::App;
-use crate::constants::{DOCS_URL, Pages, Popups, SLEEP_DURATION_RESIGN_MS};
+use crate::constants::{
+    DOCS_URL, Pages, Popups, SLEEP_DURATION_RESIGN_MS, lichess_api_url, set_lichess_api_url,
+};
 use crate::game_logic::game::GameState;
 use crate::game_logic::opponent::Opponent;
 use crate::game_logic::puzzle::PuzzleGame;
@@ -58,6 +60,49 @@ impl App {
                 self.ui_state.current_popup = Some(Popups::Error);
                 self.ui_state.show_message_popup(msg, Popups::Error);
             }
+        }
+    }
+
+    /// Opens the API URL popup, pre-filled with the URL currently in effect.
+    ///
+    /// `return_popup` is restored when the user cancels or saves, along with whatever
+    /// had been typed into it, so opening this from the token popup loses nothing.
+    pub fn open_lichess_api_url_popup(&mut self, return_popup: Option<Popups>) {
+        self.lichess_state.api_url_return_popup =
+            return_popup.map(|popup| (popup, self.game.ui.prompt.input.clone()));
+        self.game.ui.prompt.reset();
+        self.game.ui.prompt.set_input(&lichess_api_url());
+        self.ui_state.current_popup = Some(Popups::EnterLichessApiUrl);
+    }
+
+    /// Applies the API URL typed into the popup and persists it to the config file.
+    ///
+    /// An empty input restores the default endpoint. Anything that is not an
+    /// `http://` or `https://` URL is rejected inline so the popup stays open.
+    pub fn save_lichess_api_url(&mut self, raw: String) {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty()
+            && !trimmed.starts_with("http://")
+            && !trimmed.starts_with("https://")
+        {
+            self.game.ui.prompt.error = Some("URL must start with http:// or https://".to_string());
+            return;
+        }
+
+        set_lichess_api_url(trimmed);
+        self.update_config_from_app();
+        self.close_lichess_api_url_popup();
+    }
+
+    /// Restores whichever popup was showing before the API URL popup opened.
+    pub fn close_lichess_api_url_popup(&mut self) {
+        self.game.ui.prompt.reset();
+        match self.lichess_state.api_url_return_popup.take() {
+            Some((popup, previous_input)) => {
+                self.game.ui.prompt.set_input(&previous_input);
+                self.ui_state.current_popup = Some(popup);
+            }
+            None => self.ui_state.close_popup(),
         }
     }
 

--- a/src/app/lichess.rs
+++ b/src/app/lichess.rs
@@ -2,13 +2,14 @@
 
 use crate::app::App;
 use crate::constants::{
-    DOCS_URL, Pages, Popups, SLEEP_DURATION_RESIGN_MS, lichess_api_url, set_lichess_api_url,
+    DOCS_URL, Pages, Popups, SLEEP_DURATION_RESIGN_MS, append_lichess_api_suffix,
+    is_valid_lichess_api_url, lichess_api_url, lichess_api_url_has_suffix, set_lichess_api_url,
 };
 use crate::game_logic::game::GameState;
 use crate::game_logic::opponent::Opponent;
 use crate::game_logic::puzzle::PuzzleGame;
 use crate::lichess::models::LichessClient;
-use crate::state::lichess_state::LichessUpdate;
+use crate::state::lichess_state::{ApiUrlSuffixChoice, LichessUpdate};
 use shakmaty::Color;
 use std::sync::mpsc::channel;
 
@@ -53,9 +54,13 @@ impl App {
             }
             Err(e) => {
                 // Token is invalid, show error
+                // The client already explains what failed and what to try, so pass it
+                // through rather than assuming every failure is a bad token.
                 let msg = format!(
-                    "Invalid Lichess token.\n\nError: {}\n\n Please check your token and try again.\n\n Follow the documentation: {}/Lichess/setup",
-                    DOCS_URL, e
+                    "{}\n\nAPI URL: {}\n\nSetup guide: {}/Lichess/setup",
+                    e,
+                    lichess_api_url(),
+                    DOCS_URL
                 );
                 self.ui_state.current_popup = Some(Popups::Error);
                 self.ui_state.show_message_popup(msg, Popups::Error);
@@ -68,6 +73,7 @@ impl App {
     /// `return_popup` is restored when the user cancels or saves, along with whatever
     /// had been typed into it, so opening this from the token popup loses nothing.
     pub fn open_lichess_api_url_popup(&mut self, return_popup: Option<Popups>) {
+        self.lichess_state.api_url_suffix_choice = None;
         self.lichess_state.api_url_return_popup =
             return_popup.map(|popup| (popup, self.game.ui.prompt.input.clone()));
         self.game.ui.prompt.reset();
@@ -78,24 +84,50 @@ impl App {
     /// Applies the API URL typed into the popup and persists it to the config file.
     ///
     /// An empty input restores the default endpoint. Anything that is not an
-    /// `http://` or `https://` URL is rejected inline so the popup stays open.
+    /// `http://` or `https://` URL is rejected inline so the popup stays open. A URL
+    /// without the `/api` suffix is not rejected, but the popup asks about it first
+    /// via [`App::confirm_lichess_api_url_suffix`].
     pub fn save_lichess_api_url(&mut self, raw: String) {
         let trimmed = raw.trim();
-        if !trimmed.is_empty()
-            && !trimmed.starts_with("http://")
-            && !trimmed.starts_with("https://")
-        {
+        if !is_valid_lichess_api_url(trimmed) {
             self.game.ui.prompt.error = Some("URL must start with http:// or https://".to_string());
             return;
         }
 
-        set_lichess_api_url(trimmed);
+        if !lichess_api_url_has_suffix(trimmed) {
+            self.lichess_state.api_url_suffix_choice = Some(ApiUrlSuffixChoice::Append);
+            return;
+        }
+
+        self.store_lichess_api_url(trimmed.to_string());
+    }
+
+    /// Resolves the "missing `/api`" confirmation with the highlighted choice.
+    pub fn confirm_lichess_api_url_suffix(&mut self, choice: ApiUrlSuffixChoice) {
+        let typed = self.game.ui.prompt.input.trim().to_string();
+        let url = match choice {
+            ApiUrlSuffixChoice::Append => append_lichess_api_suffix(&typed),
+            ApiUrlSuffixChoice::KeepAsTyped => typed,
+        };
+        self.lichess_state.api_url_suffix_choice = None;
+        self.store_lichess_api_url(url);
+    }
+
+    /// Dismisses the "missing `/api`" confirmation and returns to editing the URL.
+    pub fn cancel_lichess_api_url_suffix(&mut self) {
+        self.lichess_state.api_url_suffix_choice = None;
+    }
+
+    /// Installs `url` as the API base URL, persists it, and closes the popup.
+    fn store_lichess_api_url(&mut self, url: String) {
+        set_lichess_api_url(&url);
         self.update_config_from_app();
         self.close_lichess_api_url_popup();
     }
 
     /// Restores whichever popup was showing before the API URL popup opened.
     pub fn close_lichess_api_url_popup(&mut self) {
+        self.lichess_state.api_url_suffix_choice = None;
         self.game.ui.prompt.reset();
         match self.lichess_state.api_url_return_popup.take() {
             Some((popup, previous_input)) => {

--- a/src/app/lichess.rs
+++ b/src/app/lichess.rs
@@ -8,7 +8,7 @@ use crate::constants::{
 use crate::game_logic::game::GameState;
 use crate::game_logic::opponent::Opponent;
 use crate::game_logic::puzzle::PuzzleGame;
-use crate::lichess::models::LichessClient;
+use crate::lichess::models::{LichessClient, unsupported_variant_name};
 use crate::state::lichess_state::{ApiUrlSuffixChoice, LichessUpdate};
 use shakmaty::Color;
 use std::sync::mpsc::channel;
@@ -411,9 +411,19 @@ impl App {
                             return true;
                         }
                         Err(e) => {
-                            log::error!("Failed to parse FEN position: {}", e);
+                            // Reached when a position is legal somewhere but not in
+                            // standard chess - a variant slipping past the variant check.
+                            log::error!(
+                                "Game {} has a position chess-tui cannot play: FEN '{}': {}",
+                                game_id,
+                                fen_str,
+                                e
+                            );
                             self.ui_state.show_message_popup(
-                                format!("Failed to parse FEN: {}", e),
+                                format!(
+                                    "Game {} is not a standard chess position, so chess-tui cannot open it.\n\nFEN: {}\n\nDetails: {}",
+                                    game_id, fen_str, e
+                                ),
                                 Popups::Error,
                             );
                             return false;
@@ -421,9 +431,19 @@ impl App {
                     }
                 }
                 Err(e) => {
-                    log::error!("Failed to parse FEN string: {}", e);
-                    self.ui_state
-                        .show_message_popup(format!("Failed to parse FEN: {}", e), Popups::Error);
+                    log::error!(
+                        "Game {} sent an unreadable FEN '{}': {}",
+                        game_id,
+                        fen_str,
+                        e
+                    );
+                    self.ui_state.show_message_popup(
+                        format!(
+                            "Game {} sent a FEN chess-tui could not read.\n\nFEN: {}\n\nDetails: {}",
+                            game_id, fen_str, e
+                        ),
+                        Popups::Error,
+                    );
                     return false;
                 }
             }
@@ -685,6 +705,26 @@ impl App {
             .ongoing_games
             .get(self.ui_state.menu_cursor as usize)
         {
+            // chess-tui models every position with shakmaty::Chess, so a variant game
+            // cannot even be parsed - a Horde FEN has no white king. Say so here rather
+            // than failing deep inside board setup.
+            if let Some(variant) = unsupported_variant_name(game.variant.as_ref()) {
+                let game_id = game.game_id.clone();
+                log::warn!(
+                    "Refusing to join game {}: variant {} is not standard chess",
+                    game_id,
+                    variant
+                );
+                self.ui_state.show_message_popup(
+                    format!(
+                        "This game is {}.\n\nchess-tui plays standard chess only, so it cannot open this game.",
+                        variant
+                    ),
+                    Popups::Error,
+                );
+                return;
+            }
+
             let game_id = game.game_id.clone();
             let color_str = game.color.clone();
             let fen = game.fen.clone();

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,8 @@ pub struct Config {
     pub bot_difficulty: Option<u8>,
     pub selected_skin_name: Option<String>,
     pub lichess_token: Option<String>,
+    /// Lichess API base URL. Overridden at startup by `CHESS_TUI_LICHESS_API_URL`.
+    pub lichess_api_url: Option<String>,
     pub sound_enabled: Option<bool>,
     pub animations_enabled: Option<bool>,
 }
@@ -67,6 +69,7 @@ impl Default for Config {
             bot_difficulty: None,
             selected_skin_name: Some("Default".to_string()),
             lichess_token: None,
+            lichess_api_url: None,
             sound_enabled: Some(true),
             animations_enabled: Some(false),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 //! Merges CLI args onto the persisted TOML config; exposes `Args` and `Config` to the rest of the crate.
 
 use crate::app::AppResult;
+use crate::constants::resolve_lichess_api_url;
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -28,6 +29,9 @@ pub struct Args {
     /// Lichess API token
     #[arg(short, long)]
     pub lichess_token: Option<String>,
+    /// Lichess API base URL (e.g. for a self-hosted instance). Defaults to https://lichess.org/api.
+    #[arg(long)]
+    pub lichess_api_url: Option<String>,
     /// Disable sound effects
     #[arg(long)]
     pub no_sound: bool,
@@ -151,6 +155,11 @@ impl Config {
         // Always update Lichess token if provided via command line
         if let Some(token) = &args.lichess_token {
             config.lichess_token = Some(token.clone());
+        }
+
+        // Always update the Lichess API URL if provided via command line
+        if let Some(api_url) = &args.lichess_api_url {
+            config.lichess_api_url = Some(resolve_lichess_api_url(Some(api_url.clone())));
         }
 
         // Update bot_depth if provided via command line

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -188,6 +188,23 @@ pub enum Popups {
 /// Default base URL for all Lichess REST API requests.
 pub const DEFAULT_LICHESS_API_URL: &str = "https://lichess.org/api";
 
+/// Path suffix a Lichess API base URL is expected to end with.
+pub const LICHESS_API_URL_SUFFIX: &str = "/api";
+
+/// OAuth scopes chess-tui needs on a Lichess personal access token.
+///
+/// Pre-selected on the token creation form linked from the token popup, so the
+/// user only has to press submit.
+pub const LICHESS_TOKEN_SCOPES: [&str; 4] = [
+    "preference:read",
+    "board:play",
+    "challenge:write",
+    "puzzle:read",
+];
+
+/// Description pre-filled on the Lichess token creation form.
+pub const LICHESS_TOKEN_DESCRIPTION: &str = "chess-tui";
+
 /// Environment variable used to override the Lichess API base URL.
 pub const LICHESS_API_URL_ENV: &str = "CHESS_TUI_LICHESS_API_URL";
 
@@ -255,14 +272,67 @@ pub fn resolve_lichess_api_url(raw: Option<String>) -> String {
         .filter(|url| !url.is_empty())
         .unwrap_or_else(|| DEFAULT_LICHESS_API_URL.to_string())
 }
+/// Returns `true` when `raw` is a usable API base URL, or blank (meaning "default").
+///
+/// Only the scheme is checked: anything reachable over HTTP is a candidate, and a
+/// wrong host can only be found out by talking to it.
+pub fn is_valid_lichess_api_url(raw: &str) -> bool {
+    let url = raw.trim();
+    url.is_empty() || url.starts_with("http://") || url.starts_with("https://")
+}
+
+/// Returns `true` when `raw` already ends with the `/api` path segment.
+///
+/// A blank value counts as having it, since it resolves to
+/// [`DEFAULT_LICHESS_API_URL`].
+pub fn lichess_api_url_has_suffix(raw: &str) -> bool {
+    let url = raw.trim().trim_end_matches('/');
+    url.is_empty() || url.ends_with(LICHESS_API_URL_SUFFIX)
+}
+
+/// Returns `raw` with `/api` appended, leaving it alone if it is already there.
+pub fn append_lichess_api_suffix(raw: &str) -> String {
+    let url = raw.trim().trim_end_matches('/');
+    if url.is_empty() {
+        return DEFAULT_LICHESS_API_URL.to_string();
+    }
+    if url.ends_with(LICHESS_API_URL_SUFFIX) {
+        url.to_string()
+    } else {
+        format!("{}{}", url, LICHESS_API_URL_SUFFIX)
+    }
+}
+
+/// Builds the token creation URL for the instance serving `api_url`.
+///
+/// The `/api` suffix is stripped to get back to the web root, and chess-tui's
+/// scopes are pre-selected so the user only has to submit the form.
+pub fn lichess_token_create_url(api_url: &str) -> String {
+    let base = api_url.trim().trim_end_matches('/');
+    let base = base
+        .strip_suffix(LICHESS_API_URL_SUFFIX)
+        .unwrap_or(base)
+        .trim_end_matches('/');
+    let scopes = LICHESS_TOKEN_SCOPES
+        .iter()
+        .map(|scope| format!("scopes[]={}", scope))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!(
+        "{}/account/oauth/token/create?{}&description={}",
+        base, scopes, LICHESS_TOKEN_DESCRIPTION
+    )
+}
+
 /// Base URL for the chess-tui documentation.
 pub const DOCS_URL: &str = "https://thomas-mauran.github.io/chess-tui/docs";
 
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_LICHESS_API_URL, lichess_api_url, resolve_lichess_api_url, set_lichess_api_url,
-        startup_lichess_api_url,
+        DEFAULT_LICHESS_API_URL, append_lichess_api_suffix, is_valid_lichess_api_url,
+        lichess_api_url, lichess_api_url_has_suffix, lichess_token_create_url,
+        resolve_lichess_api_url, set_lichess_api_url, startup_lichess_api_url,
     };
 
     #[test]
@@ -327,5 +397,48 @@ mod tests {
         // A blank value restores the default rather than emptying the URL.
         assert_eq!(set_lichess_api_url("   "), DEFAULT_LICHESS_API_URL);
         assert_eq!(lichess_api_url(), DEFAULT_LICHESS_API_URL);
+    }
+
+    #[test]
+    fn only_http_urls_are_valid_and_blank_means_default() {
+        assert!(is_valid_lichess_api_url("https://lichess.org/api"));
+        assert!(is_valid_lichess_api_url("http://localhost:9663/api"));
+        assert!(is_valid_lichess_api_url("  "));
+        assert!(!is_valid_lichess_api_url("lichess.org/api"));
+        assert!(!is_valid_lichess_api_url("ftp://lichess.org/api"));
+    }
+
+    #[test]
+    fn the_api_suffix_is_detected_through_whitespace_and_slashes() {
+        assert!(lichess_api_url_has_suffix(" https://lichess.dev/api/ "));
+        assert!(lichess_api_url_has_suffix(""));
+        assert!(!lichess_api_url_has_suffix("https://lichess.dev"));
+        assert!(!lichess_api_url_has_suffix("https://lichess.dev/apis"));
+    }
+
+    #[test]
+    fn appending_the_suffix_is_idempotent() {
+        assert_eq!(
+            append_lichess_api_suffix("https://lichess.dev/"),
+            "https://lichess.dev/api"
+        );
+        assert_eq!(
+            append_lichess_api_suffix("https://lichess.dev/api"),
+            "https://lichess.dev/api"
+        );
+        assert_eq!(append_lichess_api_suffix("  "), DEFAULT_LICHESS_API_URL);
+    }
+
+    #[test]
+    fn the_token_url_points_at_the_instance_with_scopes_preselected() {
+        assert_eq!(
+            lichess_token_create_url("https://lichess.verde.zoe/api"),
+            "https://lichess.verde.zoe/account/oauth/token/create?scopes[]=preference:read&scopes[]=board:play&scopes[]=challenge:write&scopes[]=puzzle:read&description=chess-tui"
+        );
+        // A URL saved without the /api suffix still yields the same web root.
+        assert!(
+            lichess_token_create_url("https://lichess.verde.zoe/")
+                .starts_with("https://lichess.verde.zoe/account/oauth/token/create?")
+        );
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,7 @@
 
 use core::fmt;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use ratatui::style::Color;
 use throbber_widgets_tui::Set;
@@ -182,7 +183,59 @@ pub enum Popups {
     Loading,
 }
 
+/// Default base URL for all Lichess REST API requests.
+pub const DEFAULT_LICHESS_API_URL: &str = "https://lichess.org/api";
+
+/// Environment variable used to override the Lichess API base URL.
+pub const LICHESS_API_URL_ENV: &str = "CHESS_TUI_LICHESS_API_URL";
+
 /// Base URL for all Lichess REST API requests.
-pub const LICHESS_API_URL: &str = "https://lichess.org/api";
+///
+/// Defaults to [`DEFAULT_LICHESS_API_URL`], and can be overridden by setting the
+/// `CHESS_TUI_LICHESS_API_URL` environment variable. Any trailing slashes are
+/// trimmed so callers can safely append `/some/path`.
+pub static LICHESS_API_URL: LazyLock<String> =
+    LazyLock::new(|| resolve_lichess_api_url(std::env::var(LICHESS_API_URL_ENV).ok()));
+
+/// Normalizes the raw `CHESS_TUI_LICHESS_API_URL` value, falling back to the default.
+fn resolve_lichess_api_url(raw: Option<String>) -> String {
+    raw.map(|url| url.trim().trim_end_matches('/').to_string())
+        .filter(|url| !url.is_empty())
+        .unwrap_or_else(|| DEFAULT_LICHESS_API_URL.to_string())
+}
 /// Base URL for the chess-tui documentation.
 pub const DOCS_URL: &str = "https://thomas-mauran.github.io/chess-tui/docs";
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_LICHESS_API_URL, resolve_lichess_api_url};
+
+    #[test]
+    fn unset_env_falls_back_to_default() {
+        assert_eq!(resolve_lichess_api_url(None), DEFAULT_LICHESS_API_URL);
+    }
+
+    #[test]
+    fn blank_env_falls_back_to_default() {
+        assert_eq!(
+            resolve_lichess_api_url(Some("   ".to_string())),
+            DEFAULT_LICHESS_API_URL
+        );
+    }
+
+    #[test]
+    fn custom_url_is_used() {
+        assert_eq!(
+            resolve_lichess_api_url(Some("http://localhost:9663/api".to_string())),
+            "http://localhost:9663/api"
+        );
+    }
+
+    #[test]
+    fn trailing_slashes_and_whitespace_are_trimmed() {
+        assert_eq!(
+            resolve_lichess_api_url(Some(" https://lichess.dev/api// ".to_string())),
+            "https://lichess.dev/api"
+        );
+    }
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,7 +2,7 @@
 
 use core::fmt;
 use std::path::PathBuf;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, RwLock};
 
 use ratatui::style::Color;
 use throbber_widgets_tui::Set;
@@ -173,6 +173,8 @@ pub enum Popups {
     EnterGameCode,
     /// Masked text input for the Lichess API token.
     EnterLichessToken,
+    /// Text input for the Lichess API base URL.
+    EnterLichessApiUrl,
     /// Y/N confirmation before resigning.
     ResignConfirmation,
     /// SAN move text entry.
@@ -194,11 +196,46 @@ pub const LICHESS_API_URL_ENV: &str = "CHESS_TUI_LICHESS_API_URL";
 /// Defaults to [`DEFAULT_LICHESS_API_URL`], and can be overridden by setting the
 /// `CHESS_TUI_LICHESS_API_URL` environment variable. Any trailing slashes are
 /// trimmed so callers can safely append `/some/path`.
-pub static LICHESS_API_URL: LazyLock<String> =
-    LazyLock::new(|| resolve_lichess_api_url(std::env::var(LICHESS_API_URL_ENV).ok()));
+static LICHESS_API_URL: LazyLock<RwLock<String>> = LazyLock::new(|| {
+    RwLock::new(resolve_lichess_api_url(
+        std::env::var(LICHESS_API_URL_ENV).ok(),
+    ))
+});
 
-/// Normalizes the raw `CHESS_TUI_LICHESS_API_URL` value, falling back to the default.
-fn resolve_lichess_api_url(raw: Option<String>) -> String {
+/// Returns the Lichess API base URL currently in effect, without a trailing slash.
+pub fn lichess_api_url() -> String {
+    LICHESS_API_URL
+        .read()
+        .map(|url| url.clone())
+        .unwrap_or_else(|poisoned| poisoned.into_inner().clone())
+}
+
+/// Overrides the Lichess API base URL for the rest of the process.
+///
+/// The value is normalized the same way as the environment variable: surrounding
+/// whitespace and trailing slashes are trimmed, and a blank value resets the URL
+/// to [`DEFAULT_LICHESS_API_URL`]. Returns the value that was stored.
+pub fn set_lichess_api_url(raw: &str) -> String {
+    let resolved = resolve_lichess_api_url(Some(raw.to_string()));
+    match LICHESS_API_URL.write() {
+        Ok(mut url) => *url = resolved.clone(),
+        Err(poisoned) => *poisoned.into_inner() = resolved.clone(),
+    }
+    resolved
+}
+
+/// Returns `true` when the API URL is pinned by the environment variable.
+///
+/// The variable takes precedence over the persisted config at startup, so the UI
+/// uses this to tell the user why their saved value was not applied.
+pub fn lichess_api_url_is_env_pinned() -> bool {
+    std::env::var(LICHESS_API_URL_ENV)
+        .ok()
+        .is_some_and(|url| !url.trim().is_empty())
+}
+
+/// Normalizes a raw Lichess API base URL, falling back to the default when blank.
+pub fn resolve_lichess_api_url(raw: Option<String>) -> String {
     raw.map(|url| url.trim().trim_end_matches('/').to_string())
         .filter(|url| !url.is_empty())
         .unwrap_or_else(|| DEFAULT_LICHESS_API_URL.to_string())
@@ -208,7 +245,9 @@ pub const DOCS_URL: &str = "https://thomas-mauran.github.io/chess-tui/docs";
 
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_LICHESS_API_URL, resolve_lichess_api_url};
+    use super::{
+        DEFAULT_LICHESS_API_URL, lichess_api_url, resolve_lichess_api_url, set_lichess_api_url,
+    };
 
     #[test]
     fn unset_env_falls_back_to_default() {
@@ -237,5 +276,19 @@ mod tests {
             resolve_lichess_api_url(Some(" https://lichess.dev/api// ".to_string())),
             "https://lichess.dev/api"
         );
+    }
+
+    /// One test drives the whole global so parallel tests cannot race on it.
+    #[test]
+    fn setting_the_url_at_runtime_replaces_it_and_normalizes() {
+        assert_eq!(
+            set_lichess_api_url(" http://localhost:9663/api/ "),
+            "http://localhost:9663/api"
+        );
+        assert_eq!(lichess_api_url(), "http://localhost:9663/api");
+
+        // A blank value restores the default rather than emptying the URL.
+        assert_eq!(set_lichess_api_url("   "), DEFAULT_LICHESS_API_URL);
+        assert_eq!(lichess_api_url(), DEFAULT_LICHESS_API_URL);
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -234,6 +234,21 @@ pub fn lichess_api_url_is_env_pinned() -> bool {
         .is_some_and(|url| !url.trim().is_empty())
 }
 
+/// Resolves the API URL to install at startup, or `None` to leave the current one.
+///
+/// Precedence is the command-line flag, then `CHESS_TUI_LICHESS_API_URL`, then the
+/// persisted config value. `None` means the environment variable is pinning the URL
+/// (it is already loaded into the global), so the config value must not overwrite it.
+pub fn startup_lichess_api_url(cli: Option<&str>, config: Option<&str>) -> Option<String> {
+    if let Some(cli) = cli {
+        return Some(resolve_lichess_api_url(Some(cli.to_string())));
+    }
+    if lichess_api_url_is_env_pinned() {
+        return None;
+    }
+    config.map(|url| resolve_lichess_api_url(Some(url.to_string())))
+}
+
 /// Normalizes a raw Lichess API base URL, falling back to the default when blank.
 pub fn resolve_lichess_api_url(raw: Option<String>) -> String {
     raw.map(|url| url.trim().trim_end_matches('/').to_string())
@@ -247,6 +262,7 @@ pub const DOCS_URL: &str = "https://thomas-mauran.github.io/chess-tui/docs";
 mod tests {
     use super::{
         DEFAULT_LICHESS_API_URL, lichess_api_url, resolve_lichess_api_url, set_lichess_api_url,
+        startup_lichess_api_url,
     };
 
     #[test]
@@ -276,6 +292,27 @@ mod tests {
             resolve_lichess_api_url(Some(" https://lichess.dev/api// ".to_string())),
             "https://lichess.dev/api"
         );
+    }
+
+    #[test]
+    fn the_cli_flag_beats_the_config_and_is_normalized() {
+        assert_eq!(
+            startup_lichess_api_url(Some(" https://cli.example/api/ "), Some("https://cfg/api")),
+            Some("https://cli.example/api".to_string())
+        );
+    }
+
+    #[test]
+    fn the_config_applies_when_no_flag_is_given() {
+        assert_eq!(
+            startup_lichess_api_url(None, Some("https://cfg.example/api")),
+            Some("https://cfg.example/api".to_string())
+        );
+    }
+
+    #[test]
+    fn nothing_is_applied_without_a_flag_or_config() {
+        assert_eq!(startup_lichess_api_url(None, None), None);
     }
 
     /// One test drives the whole global so parallel tests cannot race on it.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -205,6 +205,14 @@ pub const LICHESS_TOKEN_SCOPES: [&str; 4] = [
 /// Description pre-filled on the Lichess token creation form.
 pub const LICHESS_TOKEN_DESCRIPTION: &str = "chess-tui";
 
+/// Puzzle angle used when fetching and recording puzzles.
+///
+/// The Lichess puzzle routes are parameterized by an angle (a theme or opening
+/// id); `mix` is the one served when no angle is asked for. The fetch side and
+/// the submit side must always use the same angle, so if `/puzzle/next` is ever
+/// changed to request a specific one, change this with it.
+pub const PUZZLE_ANGLE: &str = "mix";
+
 /// Environment variable used to override the Lichess API base URL.
 pub const LICHESS_API_URL_ENV: &str = "CHESS_TUI_LICHESS_API_URL";
 
@@ -322,6 +330,11 @@ pub fn lichess_token_create_url(api_url: &str) -> String {
         "{}/account/oauth/token/create?{}&description={}",
         base, scopes, LICHESS_TOKEN_DESCRIPTION
     )
+}
+
+/// Builds the URL that records puzzle results on the configured instance.
+pub fn puzzle_batch_url() -> String {
+    format!("{}/puzzle/batch/{}", lichess_api_url(), PUZZLE_ANGLE)
 }
 
 /// Base URL for the chess-tui documentation.

--- a/src/game_logic/puzzle.rs
+++ b/src/game_logic/puzzle.rs
@@ -4,6 +4,7 @@ use crate::game_logic::game::Game;
 use crate::game_logic::game::GameState;
 use crate::game_logic::game_board::GameBoard;
 use crate::lichess::models::{LichessClient, Puzzle};
+use crate::lichess::puzzle::PuzzleSubmitOutcome;
 use crate::utils::get_coord_from_square;
 use shakmaty::{Position, Square};
 use std::sync::mpsc::Receiver;
@@ -19,7 +20,10 @@ pub struct PuzzleGame {
     pub submitted: bool,
     pub rating_before: Option<u16>,
     pub elo_change: Option<i32>,
-    pub elo_change_receiver: Option<Receiver<i32>>,
+    pub elo_change_receiver: Option<Receiver<PuzzleSubmitOutcome>>,
+    /// Set when the instance has no puzzle-result endpoint, so the end screen can
+    /// say why no rating change is coming instead of waiting for one forever.
+    pub submit_unsupported: bool,
 }
 
 impl PuzzleGame {
@@ -35,6 +39,7 @@ impl PuzzleGame {
             rating_before,
             elo_change: None,
             elo_change_receiver: None,
+            submit_unsupported: false,
         }
     }
 
@@ -195,10 +200,12 @@ impl PuzzleGame {
             self.elo_change_receiver = Some(rx);
 
             std::thread::spawn(move || {
-                if let Ok(rating_diff) = client.submit_puzzle_result(&puzzle_id, win, Some(time_ms))
-                {
-                    let _ = tx.send(rating_diff);
-                }
+                // Always send something: the end screen shows "Calculating Elo change..."
+                // for as long as the receiver is open, so a silent drop hangs it forever.
+                let outcome = client
+                    .submit_puzzle_result(&puzzle_id, win, Some(time_ms))
+                    .unwrap_or(PuzzleSubmitOutcome::Failed);
+                let _ = tx.send(outcome);
             });
 
             self.submitted = true;
@@ -207,9 +214,14 @@ impl PuzzleGame {
 
     pub fn check_elo_update(&mut self) {
         if let Some(ref rx) = self.elo_change_receiver
-            && let Ok(elo_change) = rx.try_recv()
+            && let Ok(outcome) = rx.try_recv()
         {
-            self.elo_change = Some(elo_change);
+            match outcome {
+                PuzzleSubmitOutcome::Rated(elo_change) => self.elo_change = Some(elo_change),
+                PuzzleSubmitOutcome::Unsupported => self.submit_unsupported = true,
+                // The error is already logged; the end screen just stops waiting.
+                PuzzleSubmitOutcome::Failed => {}
+            }
             self.elo_change_receiver = None;
         }
     }
@@ -250,98 +262,141 @@ impl PuzzleGame {
 
     pub fn load(client: &LichessClient, game_board: &mut GameBoard) -> Result<Puzzle, String> {
         match client.get_next_puzzle() {
-            Ok(puzzle) => {
-                log::info!(
-                    "Loaded puzzle: {} (rating: {})",
-                    puzzle.puzzle.id,
-                    puzzle.puzzle.rating
-                );
-                log::info!("Puzzle solution: {:?}", puzzle.puzzle.solution);
-                log::info!("Puzzle themes: {:?}", puzzle.puzzle.themes);
-                log::info!("Puzzle PGN: {}", puzzle.game.pgn);
-
-                // Extract moves from PGN (after the headers)
-                let moves_section = if let Some(moves_start) = puzzle.game.pgn.rfind("\n\n") {
-                    &puzzle.game.pgn[moves_start + 2..]
-                } else {
-                    &puzzle.game.pgn
-                };
-
-                // Parse moves (remove move numbers and result)
-                // Move numbers are in format "1." "2." etc, or just numbers
-                let move_strings: Vec<&str> = moves_section
-                    .split_whitespace()
-                    .filter(|s| {
-                        // Filter out move numbers (e.g., "1.", "2.", "35.")
-                        // Filter out results (*, 1-0, 0-1, 1/2-1/2)
-                        // But keep actual moves like "Kg4", "e4", etc.
-                        !s.ends_with('.')
-                            && *s != "*"
-                            && *s != "1-0"
-                            && *s != "0-1"
-                            && *s != "1/2-1/2"
-                    })
-                    .collect();
-
-                log::info!("Extracted moves: {:?}", move_strings);
-                log::info!("Total moves extracted: {}", move_strings.len());
-
-                // Start from the initial position
-                let mut position = shakmaty::Chess::default();
-                let mut position_history = vec![position.clone()];
-                let mut move_history = Vec::new();
-
-                // Apply moves and store them in history
-                let moves_to_apply = move_strings.len();
-                log::info!("Will apply {} moves", moves_to_apply);
-
-                for (i, move_str) in move_strings.iter().take(moves_to_apply).enumerate() {
-                    if let Ok(san) = shakmaty::san::San::from_ascii(move_str.as_bytes()) {
-                        if let Ok(chess_move) = san.to_move(&position) {
-                            // Store the move before playing it
-                            move_history.push(chess_move.clone());
-
-                            position = match position.play(&chess_move) {
-                                Ok(new_pos) => {
-                                    log::info!("Applied move {}: {}", i + 1, move_str);
-                                    // Store the position after the move
-                                    position_history.push(new_pos.clone());
-                                    new_pos
-                                }
-                                Err(e) => {
-                                    log::error!("Failed to play move {}: {}", move_str, e);
-                                    // Remove the move we just added since it failed
-                                    move_history.pop();
-                                    // Return the default position if move fails
-                                    shakmaty::Chess::default()
-                                }
-                            };
-                        } else {
-                            log::error!("Failed to convert SAN to move: {}", move_str);
-                        }
-                    } else {
-                        log::error!("Failed to parse SAN: {}", move_str);
-                    }
-                }
-
-                log::info!(
-                    "Finished applying moves. Current turn: {:?}",
-                    position.turn()
-                );
-                log::info!(
-                    "Stored {} moves and {} positions in history",
-                    move_history.len(),
-                    position_history.len()
-                );
-
-                // Set up the game with the puzzle position and all past moves
-                game_board.position_history = position_history;
-                game_board.move_history = move_history;
-                game_board.history_position_index = None;
-
-                Ok(puzzle)
-            }
+            Ok(puzzle) => Self::setup_board(puzzle, game_board),
             Err(e) => Err(e.to_string()),
         }
+    }
+
+    /// Sets `game_board` up for `puzzle` and hands the puzzle back.
+    ///
+    /// Split out of [`PuzzleGame::load`] so it can be tested without a live client:
+    /// this is where the two payload shapes diverge.
+    pub fn setup_board(puzzle: Puzzle, game_board: &mut GameBoard) -> Result<Puzzle, String> {
+        log::info!(
+            "Loaded puzzle: {} (rating: {})",
+            puzzle.puzzle.id,
+            puzzle.puzzle.rating
+        );
+        log::info!("Puzzle solution: {:?}", puzzle.puzzle.solution);
+        log::info!("Puzzle themes: {:?}", puzzle.puzzle.themes);
+        log::info!("Puzzle PGN: {}", puzzle.game.pgn);
+        log::info!("Puzzle game clock: {:?}", puzzle.game.clock);
+
+        // Extract moves from PGN (after the headers)
+        let moves_section = if let Some(moves_start) = puzzle.game.pgn.rfind("\n\n") {
+            &puzzle.game.pgn[moves_start + 2..]
+        } else {
+            &puzzle.game.pgn
+        };
+
+        // Parse moves (remove move numbers and result)
+        // Move numbers are in format "1." "2." etc, or just numbers
+        let move_strings: Vec<&str> = moves_section
+            .split_whitespace()
+            .filter(|s| {
+                // Filter out move numbers (e.g., "1.", "2.", "35.")
+                // Filter out results (*, 1-0, 0-1, 1/2-1/2)
+                // But keep actual moves like "Kg4", "e4", etc.
+                !s.ends_with('.') && *s != "*" && *s != "1-0" && *s != "0-1" && *s != "1/2-1/2"
+            })
+            .collect();
+
+        log::info!("Extracted moves: {:?}", move_strings);
+        log::info!("Total moves extracted: {}", move_strings.len());
+
+        // Some instances serve puzzles with no game to replay, and send the
+        // puzzle's starting FEN instead. Set the board straight from it.
+        if move_strings.is_empty() {
+            let Some(fen_str) = puzzle.puzzle.fen.as_deref() else {
+                return Err(format!(
+                    "Puzzle {} arrived with neither a game PGN nor a FEN, so there is no position to set up.\n\nThis Lichess instance serves puzzles in a shape chess-tui cannot use.",
+                    puzzle.puzzle.id
+                ));
+            };
+
+            let position = shakmaty::fen::Fen::from_ascii(fen_str.as_bytes())
+                .map_err(|e| {
+                    format!(
+                        "Puzzle {} has an unreadable FEN '{}': {}",
+                        puzzle.puzzle.id, fen_str, e
+                    )
+                })?
+                .into_position::<shakmaty::Chess>(shakmaty::CastlingMode::Standard)
+                .map_err(|e| {
+                    format!(
+                        "Puzzle {} FEN '{}' is not a legal standard-chess position: {}",
+                        puzzle.puzzle.id, fen_str, e
+                    )
+                })?;
+
+            log::info!(
+                "No PGN for puzzle {}; starting from FEN {} (turn {:?})",
+                puzzle.puzzle.id,
+                fen_str,
+                position.turn()
+            );
+
+            // There is no history to step back through - the instance sent none.
+            game_board.position_history = vec![position];
+            game_board.move_history = Vec::new();
+            game_board.history_position_index = None;
+
+            return Ok(puzzle);
+        }
+
+        // Start from the initial position
+        let mut position = shakmaty::Chess::default();
+        let mut position_history = vec![position.clone()];
+        let mut move_history = Vec::new();
+
+        // Apply moves and store them in history
+        let moves_to_apply = move_strings.len();
+        log::info!("Will apply {} moves", moves_to_apply);
+
+        for (i, move_str) in move_strings.iter().take(moves_to_apply).enumerate() {
+            if let Ok(san) = shakmaty::san::San::from_ascii(move_str.as_bytes()) {
+                if let Ok(chess_move) = san.to_move(&position) {
+                    // Store the move before playing it
+                    move_history.push(chess_move.clone());
+
+                    position = match position.play(&chess_move) {
+                        Ok(new_pos) => {
+                            log::info!("Applied move {}: {}", i + 1, move_str);
+                            // Store the position after the move
+                            position_history.push(new_pos.clone());
+                            new_pos
+                        }
+                        Err(e) => {
+                            log::error!("Failed to play move {}: {}", move_str, e);
+                            // Remove the move we just added since it failed
+                            move_history.pop();
+                            // Return the default position if move fails
+                            shakmaty::Chess::default()
+                        }
+                    };
+                } else {
+                    log::error!("Failed to convert SAN to move: {}", move_str);
+                }
+            } else {
+                log::error!("Failed to parse SAN: {}", move_str);
+            }
+        }
+
+        log::info!(
+            "Finished applying moves. Current turn: {:?}",
+            position.turn()
+        );
+        log::info!(
+            "Stored {} moves and {} positions in history",
+            move_history.len(),
+            position_history.len()
+        );
+
+        // Set up the game with the puzzle position and all past moves
+        game_board.position_history = position_history;
+        game_board.move_history = move_history;
+        game_board.history_position_index = None;
+
+        Ok(puzzle)
     }
 }

--- a/src/handlers/lichess/lichess_menu.rs
+++ b/src/handlers/lichess/lichess_menu.rs
@@ -12,6 +12,7 @@ pub enum LichessMenuItems {
     Puzzle,
     MyOngoingGames,
     JoinByCode,
+    ApiUrl,
     Disconnect,
 }
 
@@ -22,7 +23,8 @@ impl From<u8> for LichessMenuItems {
             1 => LichessMenuItems::Puzzle,
             2 => LichessMenuItems::MyOngoingGames,
             3 => LichessMenuItems::JoinByCode,
-            4 => LichessMenuItems::Disconnect,
+            4 => LichessMenuItems::ApiUrl,
+            5 => LichessMenuItems::Disconnect,
             _ => unreachable!("Invalid LichessMenuItems value: {value}"),
         }
     }
@@ -32,8 +34,8 @@ impl From<u8> for LichessMenuItems {
 /// Supports navigation through menu items and selection.
 pub fn handle_lichess_menu_page_events(app: &mut App, key_event: KeyEvent) {
     match key_event.code {
-        KeyCode::Up | KeyCode::Char('k') => app.ui_state.menu_cursor_up(5), // 5 menu options
-        KeyCode::Down | KeyCode::Char('j') => app.ui_state.menu_cursor_down(5),
+        KeyCode::Up | KeyCode::Char('k') => app.ui_state.menu_cursor_up(6), // 6 menu options
+        KeyCode::Down | KeyCode::Char('j') => app.ui_state.menu_cursor_down(6),
         KeyCode::PageUp => {
             // Scroll stats up
             if app.lichess_state.lichess_stats_scroll > 0 {
@@ -133,6 +135,9 @@ pub fn handle_lichess_menu_page_events(app: &mut App, key_event: KeyEvent) {
                     }
                     app.ui_state.current_popup = Some(Popups::EnterGameCode);
                     app.game.ui.prompt.reset();
+                }
+                LichessMenuItems::ApiUrl => {
+                    app.open_lichess_api_url_popup(None);
                 }
                 LichessMenuItems::Disconnect => {
                     // Disconnect

--- a/src/handlers/popup.rs
+++ b/src/handlers/popup.rs
@@ -4,6 +4,7 @@ use crate::{
     app::App,
     constants::{Pages, Popups},
     handlers::handler::fallback_key_handler,
+    state::lichess_state::ApiUrlSuffixChoice,
     utils::normalize_lowercase_to_san,
 };
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
@@ -247,6 +248,23 @@ fn handle_enter_lichess_token(app: &mut App, key_event: KeyEvent) {
 }
 
 fn handle_enter_lichess_api_url(app: &mut App, key_event: KeyEvent) {
+    // While the "missing /api" confirmation is up, the keys pick a button instead
+    // of editing the URL, so that branch has to come first.
+    if let Some(choice) = app.lichess_state.api_url_suffix_choice {
+        match key_event.code {
+            KeyCode::Enter => app.confirm_lichess_api_url_suffix(choice),
+            KeyCode::Left | KeyCode::Right | KeyCode::Tab => {
+                app.lichess_state.api_url_suffix_choice = Some(match choice {
+                    ApiUrlSuffixChoice::Append => ApiUrlSuffixChoice::KeepAsTyped,
+                    ApiUrlSuffixChoice::KeepAsTyped => ApiUrlSuffixChoice::Append,
+                });
+            }
+            KeyCode::Esc => app.cancel_lichess_api_url_suffix(),
+            _ => {}
+        }
+        return;
+    }
+
     match key_event.code {
         KeyCode::Enter => {
             let url = app.game.ui.prompt.input.clone();

--- a/src/handlers/popup.rs
+++ b/src/handlers/popup.rs
@@ -26,6 +26,7 @@ pub fn handle_popup_input(app: &mut App, key_event: KeyEvent, popup: Popups) {
         Popups::LoadPgnPath => handle_load_pgn_path(app, key_event),
         Popups::EnterGameCode => handle_enter_game_code(app, key_event),
         Popups::EnterLichessToken => handle_enter_lichess_token(app, key_event),
+        Popups::EnterLichessApiUrl => handle_enter_lichess_api_url(app, key_event),
         Popups::SeekingLichessGame => handle_seeking_lichess_game(app, key_event),
         Popups::ResignConfirmation => handle_resign_confirmation(app, key_event),
         Popups::MoveInputSelection => handle_move_input_selection(app, key_event),
@@ -235,11 +236,27 @@ fn handle_enter_lichess_token(app: &mut App, key_event: KeyEvent) {
                 app.ui_state.close_popup();
             }
         }
+        KeyCode::Tab => app.open_lichess_api_url_popup(Some(Popups::EnterLichessToken)),
         KeyCode::Char(to_insert) => app.game.ui.prompt.enter_char(to_insert),
         KeyCode::Backspace => app.game.ui.prompt.delete_char(),
         KeyCode::Left => app.game.ui.prompt.move_cursor_left(),
         KeyCode::Right => app.game.ui.prompt.move_cursor_right(),
         KeyCode::Esc => app.ui_state.close_popup(),
+        _ => fallback_key_handler(app, key_event),
+    }
+}
+
+fn handle_enter_lichess_api_url(app: &mut App, key_event: KeyEvent) {
+    match key_event.code {
+        KeyCode::Enter => {
+            let url = app.game.ui.prompt.input.clone();
+            app.save_lichess_api_url(url);
+        }
+        KeyCode::Char(to_insert) => app.game.ui.prompt.enter_char(to_insert),
+        KeyCode::Backspace => app.game.ui.prompt.delete_char(),
+        KeyCode::Left => app.game.ui.prompt.move_cursor_left(),
+        KeyCode::Right => app.game.ui.prompt.move_cursor_right(),
+        KeyCode::Esc => app.close_lichess_api_url_popup(),
         _ => fallback_key_handler(app, key_event),
     }
 }

--- a/src/lichess/account.rs
+++ b/src/lichess/account.rs
@@ -1,6 +1,7 @@
 //! Account and profile endpoints.
 
 use crate::constants::lichess_api_url;
+use crate::lichess::errors::{status_error, transport_error};
 use crate::lichess::models::{
     LichessClient, OngoingGame, OngoingGamesResponse, RatingHistoryEntry, UserProfile,
 };
@@ -19,13 +20,18 @@ impl LichessClient {
                 "chess-tui (https://github.com/thomas-mauran/chess-tui)",
             )
             .bearer_auth(&self.token)
-            .send()?;
+            .send()
+            .map_err(|e| transport_error("reach the Lichess server", &url, &e))?;
 
-        if !response.status().is_success() {
-            return Err(format!("Failed to fetch user profile: {}", response.status()).into());
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().unwrap_or_default();
+            return Err(status_error("fetch your Lichess profile", &url, status, &body).into());
         }
 
-        let profile: UserProfile = response.json()?;
+        let profile: UserProfile = response
+            .json()
+            .map_err(|e| transport_error("read your Lichess profile", &url, &e))?;
         log::info!("Fetched user profile: {}", profile.username);
         Ok(profile)
     }
@@ -45,13 +51,18 @@ impl LichessClient {
                 "chess-tui (https://github.com/thomas-mauran/chess-tui)",
             )
             .bearer_auth(&self.token)
-            .send()?;
+            .send()
+            .map_err(|e| transport_error("reach the Lichess server", &url, &e))?;
 
-        if !response.status().is_success() {
-            return Err(format!("Failed to fetch rating history: {}", response.status()).into());
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().unwrap_or_default();
+            return Err(status_error("fetch your rating history", &url, status, &body).into());
         }
 
-        let history: Vec<RatingHistoryEntry> = response.json()?;
+        let history: Vec<RatingHistoryEntry> = response
+            .json()
+            .map_err(|e| transport_error("read your rating history", &url, &e))?;
         log::info!(
             "Fetched rating history with {} time controls",
             history.len()
@@ -71,16 +82,18 @@ impl LichessClient {
                 "chess-tui (https://github.com/thomas-mauran/chess-tui)",
             )
             .bearer_auth(&self.token)
-            .send()?;
+            .send()
+            .map_err(|e| transport_error("reach the Lichess server", &url, &e))?;
 
-        if !response.status().is_success() {
-            if response.status() == reqwest::StatusCode::UNAUTHORIZED {
-                return Err("Invalid token. Please check your token or generate a new one.".into());
-            }
-            return Err(format!("Failed to fetch ongoing games: {}", response.status()).into());
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().unwrap_or_default();
+            return Err(status_error("fetch your ongoing games", &url, status, &body).into());
         }
 
-        let games_response: OngoingGamesResponse = response.json()?;
+        let games_response: OngoingGamesResponse = response
+            .json()
+            .map_err(|e| transport_error("read your ongoing games", &url, &e))?;
         log::info!("Found {} ongoing games", games_response.now_playing.len());
         Ok(games_response.now_playing)
     }

--- a/src/lichess/account.rs
+++ b/src/lichess/account.rs
@@ -8,7 +8,7 @@ use std::error::Error;
 
 impl LichessClient {
     pub fn get_user_profile(&self) -> Result<UserProfile, Box<dyn Error>> {
-        let url = format!("{}/account", LICHESS_API_URL);
+        let url = format!("{}/account", LICHESS_API_URL.as_str());
         log::info!("Fetching user profile from: {}", url);
 
         let response = self
@@ -34,7 +34,11 @@ impl LichessClient {
         &self,
         username: &str,
     ) -> Result<Vec<RatingHistoryEntry>, Box<dyn Error>> {
-        let url = format!("{}/user/{}/rating-history", LICHESS_API_URL, username);
+        let url = format!(
+            "{}/user/{}/rating-history",
+            LICHESS_API_URL.as_str(),
+            username
+        );
         log::info!("Fetching rating history from: {}", url);
 
         let response = self
@@ -60,7 +64,7 @@ impl LichessClient {
     }
 
     pub fn get_ongoing_games(&self) -> Result<Vec<OngoingGame>, Box<dyn Error>> {
-        let url = format!("{}/account/playing", LICHESS_API_URL);
+        let url = format!("{}/account/playing", LICHESS_API_URL.as_str());
         log::info!("Fetching ongoing games from: {}", url);
 
         let response = self

--- a/src/lichess/account.rs
+++ b/src/lichess/account.rs
@@ -1,6 +1,6 @@
 //! Account and profile endpoints.
 
-use crate::constants::LICHESS_API_URL;
+use crate::constants::lichess_api_url;
 use crate::lichess::models::{
     LichessClient, OngoingGame, OngoingGamesResponse, RatingHistoryEntry, UserProfile,
 };
@@ -8,7 +8,7 @@ use std::error::Error;
 
 impl LichessClient {
     pub fn get_user_profile(&self) -> Result<UserProfile, Box<dyn Error>> {
-        let url = format!("{}/account", LICHESS_API_URL.as_str());
+        let url = format!("{}/account", lichess_api_url());
         log::info!("Fetching user profile from: {}", url);
 
         let response = self
@@ -34,11 +34,7 @@ impl LichessClient {
         &self,
         username: &str,
     ) -> Result<Vec<RatingHistoryEntry>, Box<dyn Error>> {
-        let url = format!(
-            "{}/user/{}/rating-history",
-            LICHESS_API_URL.as_str(),
-            username
-        );
+        let url = format!("{}/user/{}/rating-history", lichess_api_url(), username);
         log::info!("Fetching rating history from: {}", url);
 
         let response = self
@@ -64,7 +60,7 @@ impl LichessClient {
     }
 
     pub fn get_ongoing_games(&self) -> Result<Vec<OngoingGame>, Box<dyn Error>> {
-        let url = format!("{}/account/playing", LICHESS_API_URL.as_str());
+        let url = format!("{}/account/playing", lichess_api_url());
         log::info!("Fetching ongoing games from: {}", url);
 
         let response = self

--- a/src/lichess/errors.rs
+++ b/src/lichess/errors.rs
@@ -1,0 +1,211 @@
+//! Turns HTTP failures into messages that name the likely cause.
+//!
+//! Every Lichess call goes through a configurable base URL, so a failure can just
+//! as easily be a bad host or a missing `/api` suffix as a bad token. These helpers
+//! keep that context — the URL, the status, and what to try next — in the message
+//! the user actually sees.
+
+use crate::constants::{
+    LICHESS_API_URL_SUFFIX, LICHESS_TOKEN_SCOPES, lichess_api_url, lichess_api_url_has_suffix,
+    lichess_token_create_url,
+};
+use reqwest::StatusCode;
+use std::error::Error;
+
+/// Describes a request that never got a response: DNS, TCP, TLS, or a timeout.
+pub fn transport_error(action: &str, url: &str, err: &reqwest::Error) -> String {
+    let cause = cause_chain(err);
+    let hint = if err.is_timeout() {
+        format!(
+            "The server did not answer in time. Check that {} is reachable from this machine.",
+            base_host()
+        )
+    } else if err.is_connect() {
+        format!(
+            "Could not open a connection to {}. Check the host name, the port, and its TLS certificate.",
+            base_host()
+        )
+    } else if err.is_builder() || err.is_request() {
+        format!("The request could not be built for {}.", lichess_api_url())
+    } else if err.is_decode() {
+        format!(
+            "The response from {} was not the JSON the API returns. {}",
+            url,
+            wrong_base_url_hint()
+        )
+    } else {
+        format!("Request to {} failed.", url)
+    };
+
+    format!("Could not {}.\n\n{}\n\nDetails: {}", action, hint, cause)
+}
+
+/// Describes a response whose status was not a success.
+///
+/// `body` is the response body, if it was read; it is trimmed and truncated since
+/// a wrong base URL usually returns a whole HTML page.
+pub fn status_error(action: &str, url: &str, status: StatusCode, body: &str) -> String {
+    let hint = match status {
+        StatusCode::UNAUTHORIZED => format!(
+            "The server rejected the token. Generate a new one for this instance:\n{}",
+            lichess_token_create_url(&lichess_api_url())
+        ),
+        StatusCode::FORBIDDEN => format!(
+            "The token is missing a scope. chess-tui needs: {}.\nGenerate one with them ticked:\n{}",
+            LICHESS_TOKEN_SCOPES.join(", "),
+            lichess_token_create_url(&lichess_api_url())
+        ),
+        StatusCode::NOT_FOUND => {
+            format!("The server has no such endpoint. {}", wrong_base_url_hint())
+        }
+        StatusCode::TOO_MANY_REQUESTS => {
+            "Rate limit exceeded. Wait a minute before trying again.".to_string()
+        }
+        status if status.is_server_error() => format!(
+            "The server at {} reported an internal error, so this is very likely not a problem on your side.",
+            base_host()
+        ),
+        _ => format!("Unexpected response from {}.", url),
+    };
+
+    let mut message = format!(
+        "Could not {}.\n\n{}\n\nHTTP {} from {}",
+        action, hint, status, url
+    );
+    if let Some(snippet) = body_snippet(body) {
+        message.push_str(&format!("\nResponse: {}", snippet));
+    }
+    message
+}
+
+/// Points at the base URL when the response does not look like the API at all.
+///
+/// A base URL without `/api` is the common cause: the web root answers, so the
+/// host looks healthy while every API call lands on a page that is not one.
+fn wrong_base_url_hint() -> String {
+    let base = lichess_api_url();
+    if lichess_api_url_has_suffix(&base) {
+        format!(
+            "Check that {} is the API base URL of a Lichess server.",
+            base
+        )
+    } else {
+        format!(
+            "The configured base URL {} does not end in {}, which is where Lichess serves its API. Try {}{} instead.",
+            base, LICHESS_API_URL_SUFFIX, base, LICHESS_API_URL_SUFFIX
+        )
+    }
+}
+
+/// Host part of the configured base URL, for messages about reachability.
+fn base_host() -> String {
+    let base = lichess_api_url();
+    base.split_once("://")
+        .map(|(scheme, rest)| {
+            let host = rest.split('/').next().unwrap_or(rest);
+            format!("{}://{}", scheme, host)
+        })
+        .unwrap_or(base)
+}
+
+/// Flattens an error and its sources, which is where the real cause usually is.
+fn cause_chain(err: &dyn Error) -> String {
+    let mut parts = vec![err.to_string()];
+    let mut source = err.source();
+    while let Some(cause) = source {
+        let text = cause.to_string();
+        // Reqwest repeats its own message in the first source; skip the duplicate.
+        if !parts.contains(&text) {
+            parts.push(text);
+        }
+        source = cause.source();
+    }
+    parts.join(": ")
+}
+
+/// Trims a response body down to one short, single-line snippet.
+fn body_snippet(body: &str) -> Option<String> {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let single_line = trimmed.split_whitespace().collect::<Vec<_>>().join(" ");
+    let snippet: String = single_line.chars().take(160).collect();
+    Some(if single_line.chars().count() > 160 {
+        format!("{}…", snippet)
+    } else {
+        snippet
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{body_snippet, status_error, wrong_base_url_hint};
+    use crate::constants::{DEFAULT_LICHESS_API_URL, set_lichess_api_url};
+    use reqwest::StatusCode;
+
+    /// The base URL is a process-wide global, so one test drives every case that
+    /// depends on it rather than racing a sibling test that also writes it.
+    #[test]
+    fn messages_name_the_likely_cause() {
+        set_lichess_api_url("https://lichess.verde.zoe");
+
+        // A base URL without /api is the reason every endpoint 404s, so say so.
+        let hint = wrong_base_url_hint();
+        assert!(hint.contains("does not end in /api"), "{hint}");
+        assert!(hint.contains("https://lichess.verde.zoe/api"), "{hint}");
+
+        let not_found = status_error(
+            "fetch your Lichess profile",
+            "https://lichess.verde.zoe/account",
+            StatusCode::NOT_FOUND,
+            "<html>404</html>",
+        );
+        assert!(not_found.contains("does not end in /api"), "{not_found}");
+        assert!(not_found.contains("404"), "{not_found}");
+
+        set_lichess_api_url("https://lichess.verde.zoe/api");
+        let forbidden = status_error(
+            "seek a game",
+            "https://lichess.verde.zoe/api/board/seek",
+            StatusCode::FORBIDDEN,
+            "",
+        );
+        assert!(forbidden.contains("board:play"), "{forbidden}");
+        assert!(
+            forbidden.contains("account/oauth/token/create"),
+            "{forbidden}"
+        );
+
+        let unauthorized = status_error(
+            "fetch your Lichess profile",
+            "https://lichess.verde.zoe/api/account",
+            StatusCode::UNAUTHORIZED,
+            r#"{"error":"Missing authorization header"}"#,
+        );
+        assert!(
+            unauthorized.contains("rejected the token"),
+            "{unauthorized}"
+        );
+        assert!(
+            unauthorized.contains("Missing authorization header"),
+            "{unauthorized}"
+        );
+
+        set_lichess_api_url(DEFAULT_LICHESS_API_URL);
+    }
+
+    #[test]
+    fn body_snippets_are_single_line_and_bounded() {
+        assert_eq!(body_snippet("   "), None);
+        assert_eq!(
+            body_snippet("  line one\n  line two  "),
+            Some("line one line two".to_string())
+        );
+
+        let long = "x".repeat(400);
+        let snippet = body_snippet(&long).unwrap_or_default();
+        assert_eq!(snippet.chars().count(), 161, "160 chars plus the ellipsis");
+        assert!(snippet.ends_with('…'));
+    }
+}

--- a/src/lichess/errors.rs
+++ b/src/lichess/errors.rs
@@ -37,7 +37,10 @@ pub fn transport_error(action: &str, url: &str, err: &reqwest::Error) -> String 
         format!("Request to {} failed.", url)
     };
 
-    format!("Could not {}.\n\n{}\n\nDetails: {}", action, hint, cause)
+    let message = format!("Could not {}.\n\n{}\n\nDetails: {}", action, hint, cause);
+    // Popups are dismissed and lost; the log is what a bug report can be built from.
+    log::error!("{}", message);
+    message
 }
 
 /// Describes a response whose status was not a success.
@@ -75,6 +78,7 @@ pub fn status_error(action: &str, url: &str, status: StatusCode, body: &str) -> 
     if let Some(snippet) = body_snippet(body) {
         message.push_str(&format!("\nResponse: {}", snippet));
     }
+    log::error!("{}", message);
     message
 }
 

--- a/src/lichess/game.rs
+++ b/src/lichess/game.rs
@@ -23,7 +23,7 @@ impl LichessClient {
     ) -> Result<(usize, Option<String>), Box<dyn Error>> {
         // Use public stream endpoint /api/stream/game/{id} (same as polling)
         // Read the first line (gameFull event), then close the stream
-        let url = format!("{}/stream/game/{}", LICHESS_API_URL, game_id);
+        let url = format!("{}/stream/game/{}", LICHESS_API_URL.as_str(), game_id);
         let response = self
             .client
             .get(&url)
@@ -74,7 +74,7 @@ impl LichessClient {
         increment: u32,
         cancellation_token: std::sync::Arc<std::sync::atomic::AtomicBool>,
     ) -> Result<(String, Color), Box<dyn Error>> {
-        let url = format!("{}/board/seek", LICHESS_API_URL);
+        let url = format!("{}/board/seek", LICHESS_API_URL.as_str());
 
         // Track games we've seen before seeking to detect new games
         let initial_games = self.get_ongoing_games().unwrap_or_default();
@@ -260,7 +260,7 @@ impl LichessClient {
 
         // If not in ongoing games, try to accept the challenge in case it hasn't been accepted yet
         log::info!("Attempting to accept challenge: {}", game_id);
-        let accept_url = format!("{}/challenge/{}/accept", LICHESS_API_URL, game_id);
+        let accept_url = format!("{}/challenge/{}/accept", LICHESS_API_URL.as_str(), game_id);
         let accept_response = self
             .client
             .post(&accept_url)
@@ -322,7 +322,7 @@ impl LichessClient {
             }
 
             // Try to stream the game
-            let url = format!("{}/board/game/{}/stream", LICHESS_API_URL, game_id);
+            let url = format!("{}/board/game/{}/stream", LICHESS_API_URL.as_str(), game_id);
             let response = match self
                 .client
                 .get(&url)
@@ -458,7 +458,9 @@ impl LichessClient {
     pub fn make_move(&self, game_id: &str, move_str: &str) -> Result<(), Box<dyn Error>> {
         let url = format!(
             "{}/board/game/{}/move/{}",
-            LICHESS_API_URL, game_id, move_str
+            LICHESS_API_URL.as_str(),
+            game_id,
+            move_str
         );
         let response = self.client.post(&url).bearer_auth(&self.token).send()?;
 
@@ -471,7 +473,7 @@ impl LichessClient {
     /// Resign a game
     /// Uses the board API endpoint /board/game/{id}/resign
     pub fn resign_game(&self, game_id: &str) -> Result<(), Box<dyn Error>> {
-        let url = format!("{}/board/game/{}/resign", LICHESS_API_URL, game_id);
+        let url = format!("{}/board/game/{}/resign", LICHESS_API_URL.as_str(), game_id);
         log::info!("Resigning game: {}", game_id);
 
         let response = self

--- a/src/lichess/game.rs
+++ b/src/lichess/game.rs
@@ -1,6 +1,7 @@
 //! Game seek, join, and resign endpoints.
 
 use crate::constants::lichess_api_url;
+use crate::lichess::errors::{status_error, transport_error};
 use crate::lichess::models::{GameEvent, LichessClient};
 use shakmaty::Color;
 use std::error::Error;
@@ -31,10 +32,13 @@ impl LichessClient {
                 "User-Agent",
                 "chess-tui (https://github.com/thomas-mauran/chess-tui)",
             )
-            .send()?;
+            .send()
+            .map_err(|e| transport_error("reach the Lichess server", &url, &e))?;
 
-        if !response.status().is_success() {
-            return Err(format!("Failed to get game info: {}", response.status()).into());
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().unwrap_or_default();
+            return Err(status_error("read the game", &url, status, &body).into());
         }
 
         // Read the first line which should be the gameFull event
@@ -119,7 +123,8 @@ impl LichessClient {
                     ("days", "3"),
                     ("color", "random"),
                 ])
-                .send()?
+                .send()
+                .map_err(|e| transport_error("reach the Lichess server", &url, &e))?
         } else {
             // Real-time game
             let time_str = time.to_string();
@@ -133,7 +138,8 @@ impl LichessClient {
                     ("increment", &inc_str),
                     ("color", "random"),
                 ])
-                .send()?
+                .send()
+                .map_err(|e| transport_error("reach the Lichess server", &url, &e))?
         };
 
         let status = response.status();
@@ -141,21 +147,12 @@ impl LichessClient {
             let error_text = response.text().unwrap_or_default();
             log::error!("Seek request failed: {} - {}", status, error_text);
 
-            if status == reqwest::StatusCode::FORBIDDEN {
-                return Err("Token missing permissions. Please generate a new token with 'board:play' scope enabled.".into());
-            }
-            if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                return Err(
-                    "Rate limit exceeded. Please wait a minute before trying again.".into(),
-                );
-            }
-            if status == reqwest::StatusCode::UNAUTHORIZED {
-                return Err("Invalid token. Please check your token or generate a new one.".into());
-            }
+            // Only the seek-specific case is spelled out here; everything else is
+            // shared with the other endpoints.
             if status == reqwest::StatusCode::BAD_REQUEST {
                 return Err(format!("Invalid seek parameters: {}", error_text).into());
             }
-            return Err(format!("Failed to seek game: {} - {}", status, error_text).into());
+            return Err(status_error("seek a game", &url, status, &error_text).into());
         }
 
         log::info!("Seek created. Waiting for event stream to detect game start...");
@@ -462,10 +459,17 @@ impl LichessClient {
             game_id,
             move_str
         );
-        let response = self.client.post(&url).bearer_auth(&self.token).send()?;
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .map_err(|e| transport_error("reach the Lichess server", &url, &e))?;
 
-        if !response.status().is_success() {
-            return Err(format!("Failed to make move: {}", response.status()).into());
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().unwrap_or_default();
+            return Err(status_error("play your move", &url, status, &body).into());
         }
         Ok(())
     }
@@ -484,13 +488,14 @@ impl LichessClient {
                 "chess-tui (https://github.com/thomas-mauran/chess-tui)",
             )
             .bearer_auth(&self.token)
-            .send()?;
+            .send()
+            .map_err(|e| transport_error("reach the Lichess server", &url, &e))?;
 
-        if !response.status().is_success() {
-            let status = response.status();
+        let status = response.status();
+        if !status.is_success() {
             let error_text = response.text().unwrap_or_default();
             log::error!("Failed to resign game: {} - {}", status, error_text);
-            return Err(format!("Failed to resign game: {} - {}", status, error_text).into());
+            return Err(status_error("resign the game", &url, status, &error_text).into());
         }
 
         log::info!("Successfully resigned game: {}", game_id);

--- a/src/lichess/game.rs
+++ b/src/lichess/game.rs
@@ -1,6 +1,6 @@
 //! Game seek, join, and resign endpoints.
 
-use crate::constants::LICHESS_API_URL;
+use crate::constants::lichess_api_url;
 use crate::lichess::models::{GameEvent, LichessClient};
 use shakmaty::Color;
 use std::error::Error;
@@ -23,7 +23,7 @@ impl LichessClient {
     ) -> Result<(usize, Option<String>), Box<dyn Error>> {
         // Use public stream endpoint /api/stream/game/{id} (same as polling)
         // Read the first line (gameFull event), then close the stream
-        let url = format!("{}/stream/game/{}", LICHESS_API_URL.as_str(), game_id);
+        let url = format!("{}/stream/game/{}", lichess_api_url(), game_id);
         let response = self
             .client
             .get(&url)
@@ -74,7 +74,7 @@ impl LichessClient {
         increment: u32,
         cancellation_token: std::sync::Arc<std::sync::atomic::AtomicBool>,
     ) -> Result<(String, Color), Box<dyn Error>> {
-        let url = format!("{}/board/seek", LICHESS_API_URL.as_str());
+        let url = format!("{}/board/seek", lichess_api_url());
 
         // Track games we've seen before seeking to detect new games
         let initial_games = self.get_ongoing_games().unwrap_or_default();
@@ -260,7 +260,7 @@ impl LichessClient {
 
         // If not in ongoing games, try to accept the challenge in case it hasn't been accepted yet
         log::info!("Attempting to accept challenge: {}", game_id);
-        let accept_url = format!("{}/challenge/{}/accept", LICHESS_API_URL.as_str(), game_id);
+        let accept_url = format!("{}/challenge/{}/accept", lichess_api_url(), game_id);
         let accept_response = self
             .client
             .post(&accept_url)
@@ -322,7 +322,7 @@ impl LichessClient {
             }
 
             // Try to stream the game
-            let url = format!("{}/board/game/{}/stream", LICHESS_API_URL.as_str(), game_id);
+            let url = format!("{}/board/game/{}/stream", lichess_api_url(), game_id);
             let response = match self
                 .client
                 .get(&url)
@@ -458,7 +458,7 @@ impl LichessClient {
     pub fn make_move(&self, game_id: &str, move_str: &str) -> Result<(), Box<dyn Error>> {
         let url = format!(
             "{}/board/game/{}/move/{}",
-            LICHESS_API_URL.as_str(),
+            lichess_api_url(),
             game_id,
             move_str
         );
@@ -473,7 +473,7 @@ impl LichessClient {
     /// Resign a game
     /// Uses the board API endpoint /board/game/{id}/resign
     pub fn resign_game(&self, game_id: &str) -> Result<(), Box<dyn Error>> {
-        let url = format!("{}/board/game/{}/resign", LICHESS_API_URL.as_str(), game_id);
+        let url = format!("{}/board/game/{}/resign", lichess_api_url(), game_id);
         log::info!("Resigning game: {}", game_id);
 
         let response = self

--- a/src/lichess/mod.rs
+++ b/src/lichess/mod.rs
@@ -1,6 +1,7 @@
 //! Lichess REST API client.
 
 pub mod account;
+pub mod errors;
 pub mod game;
 pub mod models;
 pub mod puzzle;

--- a/src/lichess/models.rs
+++ b/src/lichess/models.rs
@@ -45,9 +45,38 @@ pub struct EventStreamGame {
     #[serde(rename = "gameId")]
     pub game_id: String,
     pub color: String,
-    // We only need game_id and color, but keep minimal structure for deserialization
+    /// chess-tui plays standard chess only, so the variant decides whether the
+    /// game can be set up at all. See [`GameVariant::is_standard`].
+    #[serde(default)]
+    pub variant: Option<GameVariant>,
+    // We only need game_id, color and variant, but keep minimal structure for deserialization
     #[serde(flatten)]
     _rest: serde_json::Value,
+}
+
+/// Rule set a game is played under, as reported by the API.
+///
+/// chess-tui models every position with [`shakmaty::Chess`], so anything other
+/// than `standard` cannot be parsed, let alone played: a Horde FEN has no white
+/// king and its moves are illegal in standard chess from the first ply.
+#[derive(Debug, Deserialize, Clone)]
+pub struct GameVariant {
+    pub key: String,
+    pub name: String,
+}
+
+impl GameVariant {
+    /// Standard chess is the only rule set chess-tui can set up a board for.
+    pub fn is_standard(&self) -> bool {
+        self.key == "standard"
+    }
+}
+
+/// Name of a game's variant when it is one chess-tui cannot play.
+///
+/// A missing `variant` is treated as standard, which is how the API omits it.
+pub fn unsupported_variant_name(variant: Option<&GameVariant>) -> Option<String> {
+    variant.filter(|v| !v.is_standard()).map(|v| v.name.clone())
 }
 
 #[derive(Debug, Deserialize)]
@@ -72,6 +101,9 @@ pub struct OngoingGame {
     pub opponent: OpponentInfo,
     #[serde(rename = "isMyTurn")]
     pub is_my_turn: bool,
+    /// See [`GameVariant`]: non-standard games cannot be set up.
+    #[serde(default)]
+    pub variant: Option<GameVariant>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -96,8 +128,12 @@ pub struct Puzzle {
 #[derive(Debug, Deserialize, Clone)]
 pub struct PuzzleGame {
     pub id: String,
+    /// Empty on instances whose puzzle database has no game replay for the puzzle.
+    #[serde(default)]
     pub pgn: String,
-    pub clock: String,
+    /// Absent on instances whose puzzles do not come from a clocked game.
+    #[serde(default)]
+    pub clock: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -109,6 +145,12 @@ pub struct PuzzleInfo {
     pub initial_ply: u16,
     pub solution: Vec<String>,
     pub themes: Vec<String>,
+    /// Starting position of the puzzle. Sent by instances that have no game PGN
+    /// to replay, and is then the only way to set up the board.
+    #[serde(default)]
+    pub fen: Option<String>,
+    #[serde(default, rename = "lastMove")]
+    pub last_move: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/lichess/puzzle.rs
+++ b/src/lichess/puzzle.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     constants::lichess_api_url,
+    lichess::errors::{status_error, transport_error},
     lichess::models::{LichessClient, Puzzle},
 };
 use std::error::Error;
@@ -27,13 +28,18 @@ impl LichessClient {
                 "chess-tui (https://github.com/thomas-mauran/chess-tui)",
             )
             .bearer_auth(&self.token)
-            .send()?;
+            .send()
+            .map_err(|e| transport_error("reach the Lichess server", &url, &e))?;
 
-        if !response.status().is_success() {
-            return Err(format!("Failed to fetch puzzle: {}", response.status()).into());
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().unwrap_or_default();
+            return Err(status_error("fetch a puzzle", &url, status, &body).into());
         }
 
-        let puzzle: Puzzle = response.json()?;
+        let puzzle: Puzzle = response
+            .json()
+            .map_err(|e| transport_error("read the puzzle", &url, &e))?;
         log::info!(
             "Fetched puzzle: {} (rating: {})",
             puzzle.puzzle.id,
@@ -80,7 +86,8 @@ impl LichessClient {
             .header("Content-Type", "application/json")
             .bearer_auth(&self.token)
             .json(&payload)
-            .send()?;
+            .send()
+            .map_err(|e| transport_error("reach the Lichess server", &url, &e))?;
 
         let status = response.status();
         let response_text = response.text().unwrap_or_default();
@@ -94,11 +101,9 @@ impl LichessClient {
                 status,
                 response_text
             );
-            return Err(format!(
-                "Failed to submit puzzle result: {} - {}",
-                status, response_text
-            )
-            .into());
+            return Err(
+                status_error("submit the puzzle result", &url, status, &response_text).into(),
+            );
         }
 
         log::info!("✓ Puzzle result submitted successfully to Lichess!");

--- a/src/lichess/puzzle.rs
+++ b/src/lichess/puzzle.rs
@@ -1,7 +1,7 @@
 //! Puzzle fetch endpoint.
 
 use crate::{
-    constants::LICHESS_API_URL,
+    constants::lichess_api_url,
     lichess::models::{LichessClient, Puzzle},
 };
 use std::error::Error;
@@ -15,7 +15,7 @@ impl LichessClient {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis();
-        let url = format!("{}/puzzle/next?t={}", LICHESS_API_URL.as_str(), _timestamp);
+        let url = format!("{}/puzzle/next?t={}", lichess_api_url(), _timestamp);
 
         log::info!("Fetching puzzle from: {}", url);
 
@@ -61,7 +61,7 @@ impl LichessClient {
             }]
         });
 
-        let url = format!("{}/puzzle/batch/angle", LICHESS_API_URL.as_str());
+        let url = format!("{}/puzzle/batch/angle", lichess_api_url());
         log::info!("=== SUBMITTING PUZZLE RESULT ===");
         log::info!("URL: {}", url);
         log::info!("Puzzle ID: {}, Win: {}, Time: {:?}ms", puzzle_id, win, time);

--- a/src/lichess/puzzle.rs
+++ b/src/lichess/puzzle.rs
@@ -15,7 +15,7 @@ impl LichessClient {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis();
-        let url = format!("{}/puzzle/next?t={}", LICHESS_API_URL, _timestamp);
+        let url = format!("{}/puzzle/next?t={}", LICHESS_API_URL.as_str(), _timestamp);
 
         log::info!("Fetching puzzle from: {}", url);
 
@@ -61,7 +61,7 @@ impl LichessClient {
             }]
         });
 
-        let url = format!("{}/puzzle/batch/angle", LICHESS_API_URL);
+        let url = format!("{}/puzzle/batch/angle", LICHESS_API_URL.as_str());
         log::info!("=== SUBMITTING PUZZLE RESULT ===");
         log::info!("URL: {}", url);
         log::info!("Puzzle ID: {}, Win: {}, Time: {:?}ms", puzzle_id, win, time);

--- a/src/lichess/puzzle.rs
+++ b/src/lichess/puzzle.rs
@@ -49,12 +49,16 @@ impl LichessClient {
     }
 
     /// Submit puzzle result to Lichess. Returns the rating diff from the response.
+    ///
+    /// Not every instance serves the puzzle-result endpoint; a 404 there means the
+    /// result simply cannot be recorded, which is reported as
+    /// [`PuzzleSubmitOutcome::Unsupported`] rather than as a failure.
     pub fn submit_puzzle_result(
         &self,
         puzzle_id: &str,
         win: bool,
         time: Option<u32>,
-    ) -> Result<i32, Box<dyn Error>> {
+    ) -> Result<PuzzleSubmitOutcome, Box<dyn Error>> {
         use serde_json::json;
 
         // The API expects a JSON object with a "solutions" field containing an array
@@ -95,12 +99,15 @@ impl LichessClient {
         log::info!("Response status: {}", status);
         log::info!("Response body: {}", response_text);
 
-        if !status.is_success() {
-            log::error!(
-                "Failed to submit puzzle result: {} - {}",
-                status,
-                response_text
+        if status == reqwest::StatusCode::NOT_FOUND {
+            log::warn!(
+                "{} has no puzzle-result endpoint; the result was not recorded and no rating change will be shown.",
+                url
             );
+            return Ok(PuzzleSubmitOutcome::Unsupported);
+        }
+
+        if !status.is_success() {
             return Err(
                 status_error("submit the puzzle result", &url, status, &response_text).into(),
             );
@@ -109,12 +116,32 @@ impl LichessClient {
         log::info!("✓ Puzzle result submitted successfully to Lichess!");
 
         let body: serde_json::Value = serde_json::from_str(&response_text)?;
-        let rating_diff = body["rounds"]
+        // An instance that accepts the submission but returns no rounds has not
+        // recorded anything, so there is no rating change to wait for or show.
+        let Some(rating_diff) = body["rounds"]
             .as_array()
             .and_then(|r| r.first())
             .and_then(|r| r["ratingDiff"].as_i64())
-            .unwrap_or(0) as i32;
+        else {
+            log::warn!(
+                "{} accepted the puzzle result but returned no rounds, so no rating was recorded.",
+                url
+            );
+            return Ok(PuzzleSubmitOutcome::Unsupported);
+        };
 
-        Ok(rating_diff)
+        Ok(PuzzleSubmitOutcome::Rated(rating_diff as i32))
     }
+}
+
+/// What came of submitting a solved puzzle.
+#[derive(Debug, Clone, Copy)]
+pub enum PuzzleSubmitOutcome {
+    /// The instance recorded the result and reported this rating change.
+    Rated(i32),
+    /// The instance did not record the result: it either has no puzzle-result
+    /// endpoint, or accepted the submission and reported no rounds back.
+    Unsupported,
+    /// The submission failed outright. The cause is already in the log.
+    Failed,
 }

--- a/src/lichess/puzzle.rs
+++ b/src/lichess/puzzle.rs
@@ -1,7 +1,7 @@
 //! Puzzle fetch endpoint.
 
 use crate::{
-    constants::lichess_api_url,
+    constants::{lichess_api_url, puzzle_batch_url},
     lichess::errors::{status_error, transport_error},
     lichess::models::{LichessClient, Puzzle},
 };
@@ -71,7 +71,7 @@ impl LichessClient {
             }]
         });
 
-        let url = format!("{}/puzzle/batch/angle", lichess_api_url());
+        let url = puzzle_batch_url();
         log::info!("=== SUBMITTING PUZZLE RESULT ===");
         log::info!("URL: {}", url);
         log::info!("Puzzle ID: {}, Win: {}, Time: {:?}ms", puzzle_id, win, time);

--- a/src/lichess/stream.rs
+++ b/src/lichess/stream.rs
@@ -42,7 +42,7 @@ impl LichessClient {
 
         thread::spawn(move || {
             log::info!("Starting event stream thread for game detection");
-            let url = format!("{}/stream/event", LICHESS_API_URL);
+            let url = format!("{}/stream/event", LICHESS_API_URL.as_str());
 
             loop {
                 if cancellation_token.load(std::sync::atomic::Ordering::Relaxed) {
@@ -152,7 +152,8 @@ impl LichessClient {
             let mut last_status: Option<String> = None;
 
             loop {
-                let stream_url = format!("{}/board/game/stream/{}", LICHESS_API_URL, game_id);
+                let stream_url =
+                    format!("{}/board/game/stream/{}", LICHESS_API_URL.as_str(), game_id);
                 log::info!("Connecting to board game stream: {}", stream_url);
 
                 let response = match client

--- a/src/lichess/stream.rs
+++ b/src/lichess/stream.rs
@@ -1,6 +1,6 @@
 //! Board event streaming.
 
-use crate::constants::LICHESS_API_URL;
+use crate::constants::lichess_api_url;
 use crate::lichess::models::{EventStreamEvent, GameEvent, LichessClient};
 use shakmaty::Color;
 use std::error::Error;
@@ -42,7 +42,7 @@ impl LichessClient {
 
         thread::spawn(move || {
             log::info!("Starting event stream thread for game detection");
-            let url = format!("{}/stream/event", LICHESS_API_URL.as_str());
+            let url = format!("{}/stream/event", lichess_api_url());
 
             loop {
                 if cancellation_token.load(std::sync::atomic::Ordering::Relaxed) {
@@ -152,8 +152,7 @@ impl LichessClient {
             let mut last_status: Option<String> = None;
 
             loop {
-                let stream_url =
-                    format!("{}/board/game/stream/{}", LICHESS_API_URL.as_str(), game_id);
+                let stream_url = format!("{}/board/game/stream/{}", lichess_api_url(), game_id);
                 log::info!("Connecting to board game stream: {}", stream_url);
 
                 let response = match client

--- a/src/lichess/stream.rs
+++ b/src/lichess/stream.rs
@@ -1,6 +1,7 @@
 //! Board event streaming.
 
 use crate::constants::lichess_api_url;
+use crate::lichess::errors::{status_error, transport_error};
 use crate::lichess::models::{EventStreamEvent, GameEvent, LichessClient};
 use shakmaty::Color;
 use std::error::Error;
@@ -61,14 +62,19 @@ impl LichessClient {
                 {
                     Ok(resp) => resp,
                     Err(e) => {
-                        log::error!("Failed to connect to event stream: {}", e);
+                        log::error!("{}", transport_error("open the event stream", &url, &e));
                         std::thread::sleep(std::time::Duration::from_secs(5));
                         continue;
                     }
                 };
 
-                if !response.status().is_success() {
-                    log::error!("Event stream returned status: {}", response.status());
+                let status = response.status();
+                if !status.is_success() {
+                    let body = response.text().unwrap_or_default();
+                    log::error!(
+                        "{}",
+                        status_error("open the event stream", &url, status, &body)
+                    );
                     std::thread::sleep(std::time::Duration::from_secs(5));
                     continue;
                 }
@@ -166,18 +172,26 @@ impl LichessClient {
                 {
                     Ok(resp) => resp,
                     Err(e) => {
-                        log::error!("Failed to connect to board game stream: {}", e);
+                        log::error!(
+                            "{}",
+                            transport_error("open the game stream", &stream_url, &e)
+                        );
                         std::thread::sleep(std::time::Duration::from_secs(5));
                         continue;
                     }
                 };
 
-                if !response.status().is_success() {
-                    if response.status() == reqwest::StatusCode::NOT_FOUND {
+                let status = response.status();
+                if !status.is_success() {
+                    if status == reqwest::StatusCode::NOT_FOUND {
                         log::info!("Game {} not found, stopping stream", game_id);
                         break;
                     }
-                    log::error!("Game stream returned status: {}", response.status());
+                    let body = response.text().unwrap_or_default();
+                    log::error!(
+                        "{}",
+                        status_error("open the game stream", &stream_url, status, &body)
+                    );
                     std::thread::sleep(std::time::Duration::from_secs(5));
                     continue;
                 }

--- a/src/lichess/stream.rs
+++ b/src/lichess/stream.rs
@@ -2,7 +2,9 @@
 
 use crate::constants::lichess_api_url;
 use crate::lichess::errors::{status_error, transport_error};
-use crate::lichess::models::{EventStreamEvent, GameEvent, LichessClient};
+use crate::lichess::models::{
+    EventStreamEvent, GameEvent, LichessClient, unsupported_variant_name,
+};
 use shakmaty::Color;
 use std::error::Error;
 use std::sync::mpsc::Sender;
@@ -107,6 +109,17 @@ impl LichessClient {
                         Ok(EventStreamEvent::GameStart { game }) => {
                             // Check if this is a new game
                             if !initial_game_ids.contains(&game.game_id) {
+                                // Only standard chess can be set up; see GameVariant.
+                                if let Some(variant) =
+                                    unsupported_variant_name(game.variant.as_ref())
+                                {
+                                    let _ = game_found_tx.send(Err(format!(
+                                        "The game that started is {}.\n\nchess-tui plays standard chess only, so it cannot open this game.",
+                                        variant
+                                    )));
+                                    return;
+                                }
+
                                 let color = parse_game_color(&game.color);
                                 log::info!(
                                     "Event stream found new game: {} as {:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use chess_tui::app::{App, AppResult};
 use chess_tui::config::{Args, Config};
 use chess_tui::constants::{
-    DisplayMode, Pages, SKIN_NAME_ASCII, SKIN_NAME_DEFAULT, config_dir,
-    lichess_api_url_is_env_pinned, set_lichess_api_url,
+    DisplayMode, Pages, SKIN_NAME_ASCII, SKIN_NAME_DEFAULT, config_dir, set_lichess_api_url,
+    startup_lichess_api_url,
 };
 use chess_tui::event::{Event, EventHandler};
 use chess_tui::game_logic::opponent::wait_for_game_start;
@@ -52,6 +52,9 @@ fn main() -> AppResult<()> {
     // Initialize global sound state from app default
     chess_tui::sound::set_sound_enabled(app.sound_enabled);
 
+    // Persisted Lichess API URL, applied further down once the CLI flag is known.
+    let mut config_lichess_api_url: Option<String> = None;
+
     // We store the chess engine path if there is one
     if let Ok(content) = fs::read_to_string(config_path) {
         if content.trim().is_empty() {
@@ -89,13 +92,9 @@ fn main() -> AppResult<()> {
                 app.lichess_state.token = Some(lichess_token.clone());
                 app.lichess_state.client = Some(LichessClient::new(lichess_token));
             }
-            // The CHESS_TUI_LICHESS_API_URL environment variable wins over the
-            // persisted value, so only apply the config when it is not set.
-            if let Some(api_url) = config.lichess_api_url
-                && !lichess_api_url_is_env_pinned()
-            {
-                set_lichess_api_url(&api_url);
-            }
+            // Applied together with the CLI flag below so the precedence between
+            // flag, environment variable, and config lives in one place.
+            config_lichess_api_url = config.lichess_api_url;
             // Add sound enabled handling
             if let Some(sound_enabled) = config.sound_enabled {
                 app.sound_enabled = sound_enabled;
@@ -218,6 +217,15 @@ fn main() -> AppResult<()> {
     // Command line lichess token takes precedence over configuration file
     if let Some(token) = &args.lichess_token {
         app.lichess_state.token = Some(token.clone());
+    }
+
+    // Lichess API URL: command-line flag, then CHESS_TUI_LICHESS_API_URL (already
+    // loaded), then the configuration file.
+    if let Some(api_url) = startup_lichess_api_url(
+        args.lichess_api_url.as_deref(),
+        config_lichess_api_url.as_deref(),
+    ) {
+        set_lichess_api_url(&api_url);
     }
 
     // Command line no-sound flag takes precedence over configuration file
@@ -432,6 +440,7 @@ mod tests {
             depth: None,
             difficulty: None,
             lichess_token: None,
+            lichess_api_url: None,
             no_sound: false,
             skin: None,
             update_skins: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 use chess_tui::app::{App, AppResult};
 use chess_tui::config::{Args, Config};
-use chess_tui::constants::{DisplayMode, Pages, SKIN_NAME_ASCII, SKIN_NAME_DEFAULT, config_dir};
+use chess_tui::constants::{
+    DisplayMode, Pages, SKIN_NAME_ASCII, SKIN_NAME_DEFAULT, config_dir,
+    lichess_api_url_is_env_pinned, set_lichess_api_url,
+};
 use chess_tui::event::{Event, EventHandler};
 use chess_tui::game_logic::opponent::wait_for_game_start;
 use chess_tui::handlers::handler::{handle_key_events, handle_mouse_events};
@@ -85,6 +88,13 @@ fn main() -> AppResult<()> {
             if let Some(lichess_token) = config.lichess_token {
                 app.lichess_state.token = Some(lichess_token.clone());
                 app.lichess_state.client = Some(LichessClient::new(lichess_token));
+            }
+            // The CHESS_TUI_LICHESS_API_URL environment variable wins over the
+            // persisted value, so only apply the config when it is not set.
+            if let Some(api_url) = config.lichess_api_url
+                && !lichess_api_url_is_env_pinned()
+            {
+                set_lichess_api_url(&api_url);
             }
             // Add sound enabled handling
             if let Some(sound_enabled) = config.sound_enabled {

--- a/src/state/lichess_state.rs
+++ b/src/state/lichess_state.rs
@@ -1,6 +1,7 @@
 //! Holds the API token, the [`LichessClient`], incoming event channels, and the active puzzle game if any.
 
 use crate::{
+    constants::Popups,
     game_logic::puzzle::PuzzleGame,
     lichess::models::{LichessClient, LichessError, OngoingGame, RatingHistoryEntry, UserProfile},
 };
@@ -39,6 +40,9 @@ pub struct LichessState {
     pub puzzle_game: Option<PuzzleGame>,
     /// Lichess menu stats scroll offset
     pub lichess_stats_scroll: u16,
+    /// Popup to restore once the API URL popup is dismissed, together with the
+    /// prompt input it had, so a half-typed token survives the detour.
+    pub api_url_return_popup: Option<(Popups, String)>,
 }
 
 impl LichessState {

--- a/src/state/lichess_state.rs
+++ b/src/state/lichess_state.rs
@@ -8,6 +8,18 @@ use crate::{
 use shakmaty::Color;
 use std::sync::mpsc::Receiver;
 
+/// Which button is highlighted on the "missing `/api`" confirmation.
+///
+/// Appending is highlighted first because a base URL without `/api` is almost
+/// always a mistake, but the user can still keep what they typed.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ApiUrlSuffixChoice {
+    /// Save the URL with `/api` appended.
+    Append,
+    /// Save the URL exactly as it was typed.
+    KeepAsTyped,
+}
+
 pub enum LichessUpdate {
     ProfileResult(Result<Box<(UserProfile, Vec<RatingHistoryEntry>)>, String>),
     SeekResult(Result<(String, Color), String>),
@@ -43,6 +55,9 @@ pub struct LichessState {
     /// Popup to restore once the API URL popup is dismissed, together with the
     /// prompt input it had, so a half-typed token survives the detour.
     pub api_url_return_popup: Option<(Popups, String)>,
+    /// Set while the API URL popup is asking whether to append the missing `/api`
+    /// suffix; the value is the highlighted button. `None` means normal editing.
+    pub api_url_suffix_choice: Option<ApiUrlSuffixChoice>,
 }
 
 impl LichessState {

--- a/src/state/ui_state.rs
+++ b/src/state/ui_state.rs
@@ -71,6 +71,10 @@ impl UIState {
 
     /// Opens a popup and stores `message` so the UI can display it.
     pub fn show_message_popup(&mut self, message: String, popup_type: Popups) {
+        // A dismissed popup is gone; the log is what a bug report can be built from.
+        if popup_type == Popups::Error {
+            log::error!("Error popup shown: {}", message);
+        }
         self.popup_message = Some(message);
         self.current_popup = Some(popup_type);
     }

--- a/src/ui/main_ui.rs
+++ b/src/ui/main_ui.rs
@@ -114,7 +114,7 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
             render_enter_lichess_token_popup(frame, &app.game.ui.prompt);
         }
         Some(Popups::EnterLichessApiUrl) => {
-            render_enter_lichess_api_url_popup(frame, &app.game.ui.prompt);
+            render_enter_lichess_api_url_popup(frame, app);
         }
         Some(Popups::ResignConfirmation) => {
             render_resign_confirmation_popup(frame, app);

--- a/src/ui/main_ui.rs
+++ b/src/ui/main_ui.rs
@@ -22,6 +22,7 @@ use crate::{
             error::render_error_popup,
             help::render_help_popup,
             lichess::{
+                api_url::render_enter_lichess_api_url_popup,
                 game_code::render_enter_game_code_popup, puzzle_end::render_puzzle_end_popup,
                 token::render_enter_lichess_token_popup,
             },
@@ -111,6 +112,9 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
         }
         Some(Popups::EnterLichessToken) => {
             render_enter_lichess_token_popup(frame, &app.game.ui.prompt);
+        }
+        Some(Popups::EnterLichessApiUrl) => {
+            render_enter_lichess_api_url_popup(frame, &app.game.ui.prompt);
         }
         Some(Popups::ResignConfirmation) => {
             render_resign_confirmation_popup(frame, app);

--- a/src/ui/main_ui.rs
+++ b/src/ui/main_ui.rs
@@ -128,18 +128,25 @@ pub fn render(app: &mut App, frame: &mut Frame<'_>) {
             };
 
             // Check if we're still waiting for Elo change calculation
-            let (elo_change, is_calculating) = if let Some(puzzle_game) =
+            let (elo_change, is_calculating, submit_unsupported) = if let Some(puzzle_game) =
                 &app.lichess_state.puzzle_game
             {
                 (
                     puzzle_game.elo_change,
                     puzzle_game.elo_change.is_none() && puzzle_game.elo_change_receiver.is_some(),
+                    puzzle_game.submit_unsupported,
                 )
             } else {
-                (None, false)
+                (None, false, false)
             };
 
-            render_puzzle_end_popup(frame, &message, elo_change, is_calculating);
+            render_puzzle_end_popup(
+                frame,
+                &message,
+                elo_change,
+                is_calculating,
+                submit_unsupported,
+            );
         }
         Some(Popups::Loading) => {
             let message = if let Some(ref msg) = app.ui_state.popup_message {

--- a/src/ui/menu/lichess_menu.rs
+++ b/src/ui/menu/lichess_menu.rs
@@ -86,6 +86,7 @@ fn render_menu_panel(frame: &mut Frame, app: &App, area: Rect) {
         ("Puzzle", "Play a puzzle"),
         ("My Ongoing Games", "View and join your current games"),
         ("Join by Code", "Enter a game code to join"),
+        ("API URL", "Change the Lichess server to talk to"),
         ("Disconnect", "Remove Lichess token and logout"),
     ];
 
@@ -93,7 +94,7 @@ fn render_menu_panel(frame: &mut Frame, app: &App, area: Rect) {
 
     for (idx, (option, description)) in menu_items.iter().enumerate() {
         let is_selected = app.ui_state.menu_cursor == idx as u8;
-        let is_disconnect = idx == 4;
+        let is_disconnect = idx == menu_items.len() - 1;
 
         let style = if is_selected {
             if is_disconnect {

--- a/src/ui/ongoing_games.rs
+++ b/src/ui/ongoing_games.rs
@@ -1,6 +1,7 @@
 //! Ongoing Lichess games list.
 
 use crate::app::App;
+use crate::lichess::models::unsupported_variant_name;
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout},
@@ -74,6 +75,10 @@ pub fn render_ongoing_games(frame: &mut Frame, app: &App) {
                 ""
             };
 
+            // chess-tui plays standard chess only, so flag variant games here rather
+            // than letting the user select one and hit a board-setup failure.
+            let unsupported = unsupported_variant_name(game.variant.as_ref());
+
             game_lines.push(Line::from(vec![
                 Span::styled(prefix, style),
                 Span::styled(
@@ -89,6 +94,19 @@ pub fn render_ongoing_games(frame: &mut Frame, app: &App) {
                     Style::default().fg(Color::Gray),
                 ),
             ]));
+
+            if let Some(variant) = unsupported {
+                game_lines.push(Line::from(vec![
+                    Span::raw("    "),
+                    Span::styled(
+                        format!(
+                            "{} - not playable, chess-tui is standard chess only",
+                            variant
+                        ),
+                        Style::default().fg(Color::Red),
+                    ),
+                ]));
+            }
 
             game_lines.push(Line::from(""));
         }

--- a/src/ui/popup/lichess/api_url.rs
+++ b/src/ui/popup/lichess/api_url.rs
@@ -1,16 +1,20 @@
 //! Lichess API base URL entry popup.
 
+use crate::state::lichess_state::ApiUrlSuffixChoice;
 use crate::ui::prompt::Prompt;
 use crate::{
+    app::App,
     constants::{
-        DEFAULT_LICHESS_API_URL, LICHESS_API_URL_ENV, WHITE, lichess_api_url_is_env_pinned,
+        BLACK, DEFAULT_LICHESS_API_URL, LICHESS_API_URL_ENV, LICHESS_API_URL_SUFFIX, WHITE,
+        append_lichess_api_suffix, is_valid_lichess_api_url, lichess_api_url_has_suffix,
+        lichess_api_url_is_env_pinned, lichess_token_create_url,
     },
     ui::components::centered_rect::centered_rect,
 };
 use ratatui::{
     Frame,
-    layout::{Alignment, Position},
-    style::{Color, Style},
+    layout::{Alignment, Position, Rect},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap},
 };
@@ -19,7 +23,10 @@ use ratatui::{
 ///
 /// The prompt is pre-filled with the URL currently in effect, so submitting an
 /// unchanged input is a no-op. Clearing the input restores the default endpoint.
-pub fn render_enter_lichess_api_url_popup(frame: &mut Frame, prompt: &Prompt) {
+/// Submitting a URL without the `/api` suffix swaps the input for a confirmation
+/// offering to append it.
+pub fn render_enter_lichess_api_url_popup(frame: &mut Frame, app: &App) {
+    let prompt = &app.game.ui.prompt;
     let block = Block::default()
         .title("Lichess API URL")
         .borders(Borders::ALL)
@@ -28,10 +35,40 @@ pub fn render_enter_lichess_api_url_popup(frame: &mut Frame, prompt: &Prompt) {
         .border_style(Style::default().fg(WHITE));
     let area = centered_rect(70, 60, frame.area());
 
+    let text = match app.lichess_state.api_url_suffix_choice {
+        Some(choice) => missing_suffix_lines(prompt, choice),
+        None => {
+            place_cursor(frame, area, prompt);
+            editing_lines(prompt)
+        }
+    };
+
+    let paragraph = Paragraph::new(text)
+        .block(block.clone())
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: true });
+
+    frame.render_widget(Clear, area); //this clears out the background
+    frame.render_widget(block, area);
+    frame.render_widget(paragraph, area);
+}
+
+/// Draws the cursor at the current position in the input field.
+fn place_cursor(frame: &mut Frame, area: Rect, prompt: &Prompt) {
+    frame.set_cursor_position(Position::new(
+        // This position is can be controlled via the left and right arrow key
+        area.x + prompt.character_index as u16 + 2,
+        // Move one line down, from the border to the input line
+        area.y + 3,
+    ));
+}
+
+/// Body shown while the user is typing a URL.
+fn editing_lines(prompt: &Prompt) -> Vec<Line<'static>> {
     let mut text = vec![
         Line::from("Enter the Lichess API base URL:").alignment(Alignment::Center),
         Line::from(""),
-        Line::from(prompt.input.as_str()),
+        Line::from(prompt.input.clone()),
         Line::from(""),
     ];
 
@@ -46,6 +83,17 @@ pub fn render_enter_lichess_api_url_popup(frame: &mut Frame, prompt: &Prompt) {
     text.push(Line::from(format!("Default: {}", DEFAULT_LICHESS_API_URL)));
     text.push(Line::from("Leave empty to restore the default."));
 
+    // Once the URL looks usable, offer the matching token page so the user does not
+    // have to assemble the scope query string by hand.
+    if is_valid_lichess_api_url(&prompt.input) && lichess_api_url_has_suffix(&prompt.input) {
+        text.push(Line::from(""));
+        text.push(Line::from("Create a token with the right scopes:"));
+        text.push(Line::from(Span::styled(
+            lichess_token_create_url(&prompt.input),
+            Style::default().fg(Color::Cyan),
+        )));
+    }
+
     if lichess_api_url_is_env_pinned() {
         text.push(Line::from(""));
         text.push(Line::from(Span::styled(
@@ -59,21 +107,61 @@ pub fn render_enter_lichess_api_url_popup(frame: &mut Frame, prompt: &Prompt) {
 
     text.push(Line::from(""));
     text.push(Line::from("Press `Enter` to save, `Esc` to cancel.").alignment(Alignment::Center));
+    text
+}
 
-    let paragraph = Paragraph::new(text)
-        .block(block.clone())
-        .alignment(Alignment::Left)
-        .wrap(Wrap { trim: true });
+/// Body shown when the submitted URL has no `/api` suffix.
+fn missing_suffix_lines(prompt: &Prompt, choice: ApiUrlSuffixChoice) -> Vec<Line<'static>> {
+    let typed = prompt.input.trim().to_string();
+    let appended = append_lichess_api_suffix(&typed);
 
-    frame.set_cursor_position(Position::new(
-        // Draw the cursor at the current position in the input field.
-        // This position is can be controlled via the left and right arrow key
-        area.x + prompt.character_index as u16 + 2,
-        // Move one line down, from the border to the input line
-        area.y + 3,
-    ));
+    vec![
+        Line::from(Span::styled(
+            format!("This URL does not end in {}", LICHESS_API_URL_SUFFIX),
+            Style::default().fg(Color::Yellow),
+        ))
+        .alignment(Alignment::Center),
+        Line::from(""),
+        Line::from(format!("You typed: {}", typed)),
+        Line::from(""),
+        Line::from("Lichess serves its API under /api, so requests will very likely"),
+        Line::from("fail without it. You can still save the URL as typed."),
+        Line::from(""),
+        Line::from(vec![
+            button(
+                format!("Append {}", LICHESS_API_URL_SUFFIX),
+                choice == ApiUrlSuffixChoice::Append,
+            ),
+            Span::raw("  "),
+            button(
+                "Keep as typed".to_string(),
+                choice == ApiUrlSuffixChoice::KeepAsTyped,
+            ),
+        ])
+        .alignment(Alignment::Center),
+        Line::from(""),
+        Line::from(format!(
+            "Will save: {}",
+            match choice {
+                ApiUrlSuffixChoice::Append => appended,
+                ApiUrlSuffixChoice::KeepAsTyped => typed,
+            }
+        )),
+        Line::from(""),
+        Line::from("`←`/`→` to choose, `Enter` to confirm, `Esc` to keep editing.")
+            .alignment(Alignment::Center),
+    ]
+}
 
-    frame.render_widget(Clear, area); //this clears out the background
-    frame.render_widget(block, area);
-    frame.render_widget(paragraph, area);
+/// Renders one confirmation button, inverted when it is the highlighted one.
+fn button(label: String, highlighted: bool) -> Span<'static> {
+    let style = if highlighted {
+        Style::default()
+            .fg(BLACK)
+            .bg(WHITE)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(WHITE)
+    };
+    Span::styled(format!(" {} ", label), style)
 }

--- a/src/ui/popup/lichess/api_url.rs
+++ b/src/ui/popup/lichess/api_url.rs
@@ -1,0 +1,79 @@
+//! Lichess API base URL entry popup.
+
+use crate::ui::prompt::Prompt;
+use crate::{
+    constants::{
+        DEFAULT_LICHESS_API_URL, LICHESS_API_URL_ENV, WHITE, lichess_api_url_is_env_pinned,
+    },
+    ui::components::centered_rect::centered_rect,
+};
+use ratatui::{
+    Frame,
+    layout::{Alignment, Position},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap},
+};
+
+/// Renders a text input for changing the Lichess API base URL.
+///
+/// The prompt is pre-filled with the URL currently in effect, so submitting an
+/// unchanged input is a no-op. Clearing the input restores the default endpoint.
+pub fn render_enter_lichess_api_url_popup(frame: &mut Frame, prompt: &Prompt) {
+    let block = Block::default()
+        .title("Lichess API URL")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1))
+        .border_style(Style::default().fg(WHITE));
+    let area = centered_rect(70, 60, frame.area());
+
+    let mut text = vec![
+        Line::from("Enter the Lichess API base URL:").alignment(Alignment::Center),
+        Line::from(""),
+        Line::from(prompt.input.as_str()),
+        Line::from(""),
+    ];
+
+    if let Some(error) = &prompt.error {
+        text.push(Line::from(Span::styled(
+            error.clone(),
+            Style::default().fg(Color::Red),
+        )));
+        text.push(Line::from(""));
+    }
+
+    text.push(Line::from(format!("Default: {}", DEFAULT_LICHESS_API_URL)));
+    text.push(Line::from("Leave empty to restore the default."));
+
+    if lichess_api_url_is_env_pinned() {
+        text.push(Line::from(""));
+        text.push(Line::from(Span::styled(
+            format!(
+                "Note: {} is set and wins on next start.",
+                LICHESS_API_URL_ENV
+            ),
+            Style::default().fg(Color::Yellow),
+        )));
+    }
+
+    text.push(Line::from(""));
+    text.push(Line::from("Press `Enter` to save, `Esc` to cancel.").alignment(Alignment::Center));
+
+    let paragraph = Paragraph::new(text)
+        .block(block.clone())
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: true });
+
+    frame.set_cursor_position(Position::new(
+        // Draw the cursor at the current position in the input field.
+        // This position is can be controlled via the left and right arrow key
+        area.x + prompt.character_index as u16 + 2,
+        // Move one line down, from the border to the input line
+        area.y + 3,
+    ));
+
+    frame.render_widget(Clear, area); //this clears out the background
+    frame.render_widget(block, area);
+    frame.render_widget(paragraph, area);
+}

--- a/src/ui/popup/lichess/mod.rs
+++ b/src/ui/popup/lichess/mod.rs
@@ -1,5 +1,6 @@
 //! Lichess popup overlays.
 
+pub mod api_url;
 pub mod game_code;
 pub mod puzzle_end;
 pub mod token;

--- a/src/ui/popup/lichess/puzzle_end.rs
+++ b/src/ui/popup/lichess/puzzle_end.rs
@@ -13,11 +13,14 @@ use ratatui::{
 ///
 /// `elo_change` is `None` while the rating update is still being fetched from Lichess;
 /// `is_calculating` should be `true` in that interval to show a "Calculating..." message.
+/// `submit_unsupported` is `true` when the instance has no puzzle-result endpoint, in
+/// which case no rating change is coming and the popup says so instead of staying blank.
 pub fn render_puzzle_end_popup(
     frame: &mut Frame,
     sentence: &str,
     elo_change: Option<i32>,
     is_calculating: bool,
+    submit_unsupported: bool,
 ) {
     let block = Block::default()
         .title("Puzzle Complete")
@@ -54,6 +57,18 @@ pub fn render_puzzle_end_popup(
             Line::from(change_text)
                 .alignment(Alignment::Center)
                 .style(Style::default().fg(color).add_modifier(Modifier::BOLD)),
+        );
+    } else if submit_unsupported {
+        text.push(Line::from(""));
+        text.push(
+            Line::from("This Lichess instance does not record puzzle results,")
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(Color::Gray)),
+        );
+        text.push(
+            Line::from("so your rating is unchanged.")
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(Color::Gray)),
         );
     } else if is_calculating {
         text.push(Line::from(""));

--- a/src/ui/popup/lichess/token.rs
+++ b/src/ui/popup/lichess/token.rs
@@ -2,7 +2,7 @@
 
 use crate::ui::prompt::Prompt;
 use crate::{
-    constants::{DOCS_URL, WHITE},
+    constants::{DOCS_URL, WHITE, lichess_api_url},
     ui::components::centered_rect::centered_rect,
 };
 use ratatui::{
@@ -21,7 +21,7 @@ pub fn render_enter_lichess_token_popup(frame: &mut Frame, prompt: &Prompt) {
         .border_type(BorderType::Rounded)
         .padding(Padding::horizontal(1))
         .border_style(Style::default().fg(WHITE));
-    let area = centered_rect(70, 40, frame.area());
+    let area = centered_rect(70, 60, frame.area());
 
     let current_input = prompt.input.as_str();
     // Mask the token for security (show only last 4 characters)
@@ -42,9 +42,10 @@ pub fn render_enter_lichess_token_popup(frame: &mut Frame, prompt: &Prompt) {
         Line::from(""),
         Line::from(masked_input),
         Line::from(""),
+        Line::from(format!("Get a token: {}/Lichess/setup", DOCS_URL)),
         Line::from(""),
-        Line::from("To get a token, follow the documentation:"),
-        Line::from(format!("Documentation: {}/Lichess/setup", DOCS_URL)),
+        Line::from(format!("API URL: {}", lichess_api_url())),
+        Line::from("Press `Tab` to use a different Lichess server."),
         Line::from(""),
         Line::from("Press `Enter` to save, `Esc` to cancel.").alignment(Alignment::Center),
     ];

--- a/src/ui/popup/lichess/token.rs
+++ b/src/ui/popup/lichess/token.rs
@@ -2,7 +2,7 @@
 
 use crate::ui::prompt::Prompt;
 use crate::{
-    constants::{DOCS_URL, WHITE, lichess_api_url},
+    constants::{DOCS_URL, WHITE, lichess_api_url, lichess_token_create_url},
     ui::components::centered_rect::centered_rect,
 };
 use ratatui::{
@@ -42,7 +42,10 @@ pub fn render_enter_lichess_token_popup(frame: &mut Frame, prompt: &Prompt) {
         Line::from(""),
         Line::from(masked_input),
         Line::from(""),
-        Line::from(format!("Get a token: {}/Lichess/setup", DOCS_URL)),
+        Line::from("Create one with the right scopes already ticked:"),
+        Line::from(lichess_token_create_url(&lichess_api_url())),
+        Line::from(""),
+        Line::from(format!("Guide: {}/Lichess/setup", DOCS_URL)),
         Line::from(""),
         Line::from(format!("API URL: {}", lichess_api_url())),
         Line::from("Press `Tab` to use a different Lichess server."),

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -53,6 +53,15 @@ impl Prompt {
         self.reset_cursor();
     }
 
+    /// Replaces `input` with `value` and places the cursor at the end of it.
+    ///
+    /// Used to pre-fill a prompt with an existing value the user can edit.
+    pub fn set_input(&mut self, value: &str) {
+        self.input = value.to_string();
+        self.character_index = self.input.chars().count();
+        self.error = None;
+    }
+
     /// Copies `input` into `message`, then clears `input` and resets the cursor.
     pub fn submit_message(&mut self) {
         self.message = self.input.clone();

--- a/tests/lichess_api_url_env_tests.rs
+++ b/tests/lichess_api_url_env_tests.rs
@@ -1,0 +1,35 @@
+//! Precedence rules that depend on the process environment.
+//!
+//! This file deliberately holds a single test: `set_var` mutates process-global
+//! state, so it must not run alongside another test that reads the environment.
+
+use chess_tui::constants::{LICHESS_API_URL_ENV, startup_lichess_api_url};
+
+#[test]
+fn the_environment_variable_beats_the_config_but_not_the_cli_flag() {
+    // SAFETY: this is the only test in this binary, so no other thread is
+    // reading the environment while it is modified.
+    unsafe {
+        std::env::set_var(LICHESS_API_URL_ENV, "https://env.example/api");
+    }
+
+    // Nothing is applied on top of the environment value, which the global
+    // already holds, so the persisted config is ignored.
+    assert_eq!(startup_lichess_api_url(None, Some("https://cfg/api")), None);
+
+    // The flag still wins.
+    assert_eq!(
+        startup_lichess_api_url(Some("https://cli.example/api"), Some("https://cfg/api")),
+        Some("https://cli.example/api".to_string())
+    );
+
+    // SAFETY: same as above.
+    unsafe {
+        std::env::remove_var(LICHESS_API_URL_ENV);
+    }
+
+    assert_eq!(
+        startup_lichess_api_url(None, Some("https://cfg/api")),
+        Some("https://cfg/api".to_string())
+    );
+}

--- a/tests/lichess_api_url_tests.rs
+++ b/tests/lichess_api_url_tests.rs
@@ -1,0 +1,112 @@
+#[cfg(test)]
+mod lichess_api_url_tests {
+    use chess_tui::{
+        app::{App, AppResult},
+        constants::{DEFAULT_LICHESS_API_URL, Popups},
+        handlers::handler::handle_key_events,
+        ui::popup::lichess::{
+            api_url::render_enter_lichess_api_url_popup, token::render_enter_lichess_token_popup,
+        },
+    };
+    use ratatui::{
+        Terminal,
+        backend::TestBackend,
+        crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    };
+
+    fn key_press(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::empty(),
+            kind: KeyEventKind::Press,
+            state: ratatui::crossterm::event::KeyEventState::empty(),
+        }
+    }
+
+    fn render<F>(draw: F) -> AppResult<String>
+    where
+        F: FnOnce(&mut ratatui::Frame),
+    {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend)?;
+        terminal.draw(draw)?;
+
+        let buffer = terminal.backend().buffer().clone();
+        let mut rendered = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                rendered.push_str(buffer[(x, y)].symbol());
+            }
+            rendered.push('\n');
+        }
+        Ok(rendered)
+    }
+
+    #[test]
+    fn token_popup_shows_the_api_url_and_the_tab_hint() -> AppResult<()> {
+        let app = App::default();
+        let rendered =
+            render(|frame| render_enter_lichess_token_popup(frame, &app.game.ui.prompt))?;
+
+        assert!(
+            rendered.contains(DEFAULT_LICHESS_API_URL),
+            "Token popup should show the API URL in effect.\nRendered:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("Tab"),
+            "Token popup should mention the `Tab` shortcut.\nRendered:\n{rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn tab_on_the_token_popup_opens_a_prefilled_api_url_popup() -> AppResult<()> {
+        let mut app = App::default();
+        app.ui_state.current_popup = Some(Popups::EnterLichessToken);
+        app.game.ui.prompt.set_input("half-typed-token");
+
+        handle_key_events(key_press(KeyCode::Tab), &mut app)?;
+
+        assert_eq!(app.ui_state.current_popup, Some(Popups::EnterLichessApiUrl));
+        assert_eq!(app.game.ui.prompt.input, DEFAULT_LICHESS_API_URL);
+
+        let rendered =
+            render(|frame| render_enter_lichess_api_url_popup(frame, &app.game.ui.prompt))?;
+        assert!(
+            rendered.contains(DEFAULT_LICHESS_API_URL),
+            "API URL popup should be pre-filled with the current URL.\nRendered:\n{rendered}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cancelling_restores_the_token_popup_and_its_input() -> AppResult<()> {
+        let mut app = App::default();
+        app.ui_state.current_popup = Some(Popups::EnterLichessToken);
+        app.game.ui.prompt.set_input("half-typed-token");
+
+        handle_key_events(key_press(KeyCode::Tab), &mut app)?;
+        handle_key_events(key_press(KeyCode::Esc), &mut app)?;
+
+        assert_eq!(app.ui_state.current_popup, Some(Popups::EnterLichessToken));
+        assert_eq!(app.game.ui.prompt.input, "half-typed-token");
+        Ok(())
+    }
+
+    #[test]
+    fn a_url_without_a_scheme_is_rejected_inline() -> AppResult<()> {
+        let mut app = App::default();
+        app.open_lichess_api_url_popup(None);
+        app.game.ui.prompt.set_input("lichess.dev/api");
+
+        handle_key_events(key_press(KeyCode::Enter), &mut app)?;
+
+        assert_eq!(
+            app.ui_state.current_popup,
+            Some(Popups::EnterLichessApiUrl),
+            "Popup should stay open so the user can fix the URL"
+        );
+        assert!(app.game.ui.prompt.error.is_some());
+        Ok(())
+    }
+}

--- a/tests/lichess_api_url_tests.rs
+++ b/tests/lichess_api_url_tests.rs
@@ -3,8 +3,9 @@ mod lichess_api_url_tests {
     use chess_tui::{
         app::{App, AppResult},
         config::{Args, Config},
-        constants::{DEFAULT_LICHESS_API_URL, Popups},
+        constants::{DEFAULT_LICHESS_API_URL, Popups, lichess_api_url, set_lichess_api_url},
         handlers::handler::handle_key_events,
+        state::lichess_state::ApiUrlSuffixChoice,
         ui::popup::lichess::{
             api_url::render_enter_lichess_api_url_popup, token::render_enter_lichess_token_popup,
         },
@@ -71,8 +72,7 @@ mod lichess_api_url_tests {
         assert_eq!(app.ui_state.current_popup, Some(Popups::EnterLichessApiUrl));
         assert_eq!(app.game.ui.prompt.input, DEFAULT_LICHESS_API_URL);
 
-        let rendered =
-            render(|frame| render_enter_lichess_api_url_popup(frame, &app.game.ui.prompt))?;
+        let rendered = render(|frame| render_enter_lichess_api_url_popup(frame, &app))?;
         assert!(
             rendered.contains(DEFAULT_LICHESS_API_URL),
             "API URL popup should be pre-filled with the current URL.\nRendered:\n{rendered}"
@@ -108,6 +108,87 @@ mod lichess_api_url_tests {
             "Popup should stay open so the user can fix the URL"
         );
         assert!(app.game.ui.prompt.error.is_some());
+        Ok(())
+    }
+
+    /// The API URL is a process-wide global, so a single test drives both outcomes
+    /// rather than racing a sibling test that also writes it.
+    #[test]
+    fn a_url_without_the_api_suffix_asks_before_saving() -> AppResult<()> {
+        let mut app = App::default();
+        app.open_lichess_api_url_popup(None);
+        app.game.ui.prompt.set_input("https://lichess.verde.zoe");
+
+        handle_key_events(key_press(KeyCode::Enter), &mut app)?;
+
+        assert_eq!(app.ui_state.current_popup, Some(Popups::EnterLichessApiUrl));
+        assert_eq!(
+            app.lichess_state.api_url_suffix_choice,
+            Some(ApiUrlSuffixChoice::Append),
+            "Appending should be the highlighted button"
+        );
+
+        let rendered = render(|frame| render_enter_lichess_api_url_popup(frame, &app))?;
+        assert!(
+            rendered.contains("does not end in /api"),
+            "The popup should warn about the missing suffix.\nRendered:\n{rendered}"
+        );
+
+        // Confirming the highlighted button appends the suffix and closes the popup.
+        handle_key_events(key_press(KeyCode::Enter), &mut app)?;
+        assert_eq!(lichess_api_url(), "https://lichess.verde.zoe/api");
+        assert_eq!(app.ui_state.current_popup, None);
+
+        // Moving off the highlighted button keeps the URL exactly as typed.
+        app.open_lichess_api_url_popup(None);
+        app.game.ui.prompt.set_input("https://lichess.verde.zoe");
+        handle_key_events(key_press(KeyCode::Enter), &mut app)?;
+        handle_key_events(key_press(KeyCode::Right), &mut app)?;
+        assert_eq!(
+            app.lichess_state.api_url_suffix_choice,
+            Some(ApiUrlSuffixChoice::KeepAsTyped)
+        );
+        handle_key_events(key_press(KeyCode::Enter), &mut app)?;
+        assert_eq!(lichess_api_url(), "https://lichess.verde.zoe");
+
+        set_lichess_api_url(DEFAULT_LICHESS_API_URL);
+        Ok(())
+    }
+
+    #[test]
+    fn escaping_the_warning_returns_to_editing_the_url() -> AppResult<()> {
+        let mut app = App::default();
+        app.open_lichess_api_url_popup(None);
+        app.game.ui.prompt.set_input("https://lichess.verde.zoe");
+
+        handle_key_events(key_press(KeyCode::Enter), &mut app)?;
+        handle_key_events(key_press(KeyCode::Esc), &mut app)?;
+
+        assert_eq!(app.lichess_state.api_url_suffix_choice, None);
+        assert_eq!(app.ui_state.current_popup, Some(Popups::EnterLichessApiUrl));
+        assert_eq!(app.game.ui.prompt.input, "https://lichess.verde.zoe");
+        Ok(())
+    }
+
+    #[test]
+    fn a_valid_url_offers_a_scoped_token_link_for_that_instance() -> AppResult<()> {
+        let mut app = App::default();
+        app.open_lichess_api_url_popup(None);
+        app.game
+            .ui
+            .prompt
+            .set_input("https://lichess.verde.zoe/api");
+
+        let rendered = render(|frame| render_enter_lichess_api_url_popup(frame, &app))?;
+        // The rendered buffer wraps, so assert on the distinctive pieces.
+        assert!(
+            rendered.contains("account/oauth/token/create"),
+            "A valid URL should offer the token creation link.\nRendered:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("board:play"),
+            "The link should preselect the scopes chess-tui needs.\nRendered:\n{rendered}"
+        );
         Ok(())
     }
 

--- a/tests/lichess_api_url_tests.rs
+++ b/tests/lichess_api_url_tests.rs
@@ -2,6 +2,7 @@
 mod lichess_api_url_tests {
     use chess_tui::{
         app::{App, AppResult},
+        config::{Args, Config},
         constants::{DEFAULT_LICHESS_API_URL, Popups},
         handlers::handler::handle_key_events,
         ui::popup::lichess::{
@@ -107,6 +108,50 @@ mod lichess_api_url_tests {
             "Popup should stay open so the user can fix the URL"
         );
         assert!(app.game.ui.prompt.error.is_some());
+        Ok(())
+    }
+
+    fn args_with_api_url(api_url: Option<&str>) -> Args {
+        Args {
+            engine_path: String::new(),
+            depth: None,
+            difficulty: None,
+            lichess_token: None,
+            lichess_api_url: api_url.map(str::to_string),
+            no_sound: false,
+            skin: None,
+            update_skins: false,
+            pgn: None,
+        }
+    }
+
+    #[test]
+    fn the_cli_flag_is_persisted_and_normalized() -> AppResult<()> {
+        let folder = std::env::temp_dir().join("chess-tui-api-url-flag-test");
+        let config_path = folder.join("config.toml");
+        let _ = std::fs::remove_dir_all(&folder);
+
+        Config::config_create(
+            &args_with_api_url(Some(" https://lichess.dev/api/ ")),
+            &folder,
+            &config_path,
+        )?;
+
+        let written: Config = toml::from_str(&std::fs::read_to_string(&config_path)?)?;
+        assert_eq!(
+            written.lichess_api_url.as_deref(),
+            Some("https://lichess.dev/api")
+        );
+
+        // Omitting the flag must not clobber the value a previous run stored.
+        Config::config_create(&args_with_api_url(None), &folder, &config_path)?;
+        let written: Config = toml::from_str(&std::fs::read_to_string(&config_path)?)?;
+        assert_eq!(
+            written.lichess_api_url.as_deref(),
+            Some("https://lichess.dev/api")
+        );
+
+        std::fs::remove_dir_all(&folder)?;
         Ok(())
     }
 }

--- a/tests/lichess_api_url_tests.rs
+++ b/tests/lichess_api_url_tests.rs
@@ -3,7 +3,9 @@ mod lichess_api_url_tests {
     use chess_tui::{
         app::{App, AppResult},
         config::{Args, Config},
-        constants::{DEFAULT_LICHESS_API_URL, Popups, lichess_api_url, set_lichess_api_url},
+        constants::{
+            DEFAULT_LICHESS_API_URL, Popups, lichess_api_url, puzzle_batch_url, set_lichess_api_url,
+        },
         handlers::handler::handle_key_events,
         state::lichess_state::ApiUrlSuffixChoice,
         ui::popup::lichess::{
@@ -190,6 +192,20 @@ mod lichess_api_url_tests {
             "The link should preselect the scopes chess-tui needs.\nRendered:\n{rendered}"
         );
         Ok(())
+    }
+
+    #[test]
+    fn the_puzzle_result_url_names_a_real_angle() {
+        // `/puzzle/batch/{angle}` takes an angle id; the literal word "angle" is a
+        // placeholder that makes a self-hosted instance answer 404, which reads as
+        // "this instance has no puzzle endpoint".
+        // The base URL is a process-wide global that other tests in this binary
+        // rewrite, so this reads it rather than setting it.
+        assert_eq!(
+            puzzle_batch_url(),
+            format!("{}/puzzle/batch/mix", lichess_api_url())
+        );
+        assert!(puzzle_batch_url().ends_with("/puzzle/batch/mix"));
     }
 
     fn args_with_api_url(api_url: Option<&str>) -> Args {

--- a/tests/lichess_puzzle_payload_tests.rs
+++ b/tests/lichess_puzzle_payload_tests.rs
@@ -1,0 +1,188 @@
+//! Deserialization and board setup for the two puzzle payload shapes seen in the wild.
+//!
+//! lichess.org sends a game PGN and a clock; a self-hosted lila whose puzzle database
+//! has no game replay sends an empty PGN, no clock, and the puzzle's own FEN instead.
+
+use chess_tui::game_logic::game_board::GameBoard;
+use chess_tui::game_logic::puzzle::PuzzleGame;
+use chess_tui::lichess::models::{OngoingGame, Puzzle};
+use shakmaty::Position;
+
+/// Captured verbatim from a self-hosted instance: no `game.clock`, empty `game.pgn`,
+/// and a `puzzle.fen` that is the only way to set up the board.
+const SELF_HOSTED_PUZZLE: &str = r#"{
+  "game": {
+    "id": "xMCTSnVy",
+    "perf": {"key": "blitz", "name": "Blitz"},
+    "rated": true,
+    "players": [
+      {"name": "ghost", "id": "ghost", "color": "white"},
+      {"name": "ghost", "id": "ghost", "color": "black"}
+    ],
+    "pgn": ""
+  },
+  "puzzle": {
+    "id": "Jj0di",
+    "rating": 1527,
+    "plays": 3494,
+    "solution": ["b2b4", "a5b5", "c3c4", "b5c4", "a3a4"],
+    "themes": ["crushing", "deflection", "endgame", "long"],
+    "fen": "r7/8/p7/k2P1p2/q3p3/Q1P5/1P3P1P/7K w - - 1 1",
+    "lastMove": "b5a4",
+    "initialPly": 79
+  }
+}"#;
+
+/// Captured verbatim from lichess.org: full PGN and a clock, no FEN.
+const LICHESS_ORG_PUZZLE: &str = r#"{
+  "game": {
+    "id": "1tYAcSIe",
+    "perf": {"key": "rapid", "name": "Rapid"},
+    "rated": true,
+    "players": [
+      {"name": "CHESS-NO-MESS", "id": "chess-no-mess", "color": "white", "rating": 1837},
+      {"name": "CheerUp27", "id": "cheerup27", "color": "black", "rating": 1852}
+    ],
+    "pgn": "Nf3 e5 e4 Nc6 Bc4 Nf6 Nc3 Bb4 d3 O-O O-O Nd4 Nd5 Nxd5 Bxd5 c6 Bxf7+ Rxf7 Nxe5 Re7 f4 Bc5 Kh1 d6 Nf3 Nxf3 Qxf3 Be6 f5 Rf7 Qg3 Bd7 Bg5 Qe8 f6 g6 Bh6 Bd4 Bg7 Qe6 Qh4 Bxb2 Rab1 Qxa2 c4 Bd4 Rxb7 Qe2 Rbb1 Qxd3 Rbd1 Qxc4 e5 dxe5 Rc1 Qe6 Rce1 a5 Qh6 a4 Re4 Qc4",
+    "clock": "10+0"
+  },
+  "puzzle": {
+    "id": "yM2Xo",
+    "rating": 1404,
+    "plays": 23047,
+    "solution": ["h6h7", "g8h7", "e4h4", "h7g8", "h4h8"],
+    "themes": ["middlegame", "operaMate", "attraction", "long", "mateIn3", "sacrifice"],
+    "initialPly": 61
+  }
+}"#;
+
+#[test]
+fn self_hosted_puzzle_without_clock_or_pgn_deserializes() {
+    let puzzle: Puzzle =
+        serde_json::from_str(SELF_HOSTED_PUZZLE).expect("missing clock must not fail the decode");
+
+    assert_eq!(puzzle.game.clock, None);
+    assert_eq!(puzzle.game.pgn, "");
+    assert_eq!(
+        puzzle.puzzle.fen.as_deref(),
+        Some("r7/8/p7/k2P1p2/q3p3/Q1P5/1P3P1P/7K w - - 1 1")
+    );
+    assert_eq!(puzzle.puzzle.last_move.as_deref(), Some("b5a4"));
+}
+
+#[test]
+fn lichess_org_puzzle_still_deserializes() {
+    let puzzle: Puzzle = serde_json::from_str(LICHESS_ORG_PUZZLE).expect("decode");
+
+    assert_eq!(puzzle.game.clock.as_deref(), Some("10+0"));
+    assert!(puzzle.game.pgn.starts_with("Nf3 e5"));
+    assert_eq!(puzzle.puzzle.fen, None);
+}
+
+/// The FEN branch sets the board straight from `puzzle.fen`, with no history to replay.
+#[test]
+fn empty_pgn_sets_the_board_from_the_puzzle_fen() {
+    let puzzle: Puzzle = serde_json::from_str(SELF_HOSTED_PUZZLE).expect("decode");
+    let mut game_board = GameBoard::default();
+
+    let expected = shakmaty::fen::Fen::from_ascii(b"r7/8/p7/k2P1p2/q3p3/Q1P5/1P3P1P/7K w - - 1 1")
+        .expect("fixture fen parses")
+        .into_position::<shakmaty::Chess>(shakmaty::CastlingMode::Standard)
+        .expect("fixture fen is a legal standard position");
+
+    PuzzleGame::setup_board(puzzle, &mut game_board).expect("fen branch must succeed");
+
+    assert_eq!(
+        game_board.position_history.len(),
+        1,
+        "the instance sent no move history, so there is nothing to step back through"
+    );
+    assert!(game_board.move_history.is_empty());
+    assert_eq!(game_board.history_position_index, None);
+    assert_eq!(
+        game_board.position_history[0].turn(),
+        shakmaty::Color::White
+    );
+    assert_eq!(game_board.position_history[0].board(), expected.board());
+}
+
+/// The PGN branch is unchanged: the whole game is replayed into the history.
+#[test]
+fn lichess_org_pgn_still_replays_into_history() {
+    let puzzle: Puzzle = serde_json::from_str(LICHESS_ORG_PUZZLE).expect("decode");
+    let mut game_board = GameBoard::default();
+
+    PuzzleGame::setup_board(puzzle, &mut game_board).expect("pgn branch must succeed");
+
+    // 62 SAN moves in the fixture, plus the starting position.
+    assert_eq!(game_board.move_history.len(), 62);
+    assert_eq!(game_board.position_history.len(), 63);
+}
+
+/// Neither shape available is a clear error, not a silent start-position board.
+#[test]
+fn neither_pgn_nor_fen_is_a_named_error() {
+    let raw = SELF_HOSTED_PUZZLE.replace(
+        "\"fen\": \"r7/8/p7/k2P1p2/q3p3/Q1P5/1P3P1P/7K w - - 1 1\",\n    ",
+        "",
+    );
+    let puzzle: Puzzle = serde_json::from_str(&raw).expect("decode");
+    assert_eq!(puzzle.puzzle.fen, None, "the fen must actually be gone");
+
+    let mut game_board = GameBoard::default();
+    let err = PuzzleGame::setup_board(puzzle, &mut game_board)
+        .expect_err("no pgn and no fen has no position to set up");
+    assert!(err.contains("Jj0di"), "{err}");
+    assert!(err.contains("neither a game PGN nor a FEN"), "{err}");
+}
+
+/// A Horde game reaches the ongoing-games list with a variant key, and its FEN is not a
+/// legal standard-chess position - which is why the variant has to be checked first.
+#[test]
+fn horde_ongoing_game_is_flagged_and_its_fen_is_unplayable() {
+    let raw = r#"{
+      "fullId": "ZlERnWEOkxyb",
+      "gameId": "ZlERnWEO",
+      "fen": "rnbqkbnr/1p1p1p2/pP1P4/PPPPPPPP/PPPPPPPP/PPP1P1P1/2P1PPP1/PP3PPP b q - 0 35",
+      "color": "black",
+      "variant": {"key": "horde", "name": "Horde"},
+      "opponent": {"id": null, "username": "Stockfish level 8", "ai": 8},
+      "isMyTurn": true
+    }"#;
+
+    let game: OngoingGame = serde_json::from_str(raw).expect("decode");
+    let variant = game
+        .variant
+        .as_ref()
+        .expect("horde game reports its variant");
+    assert!(!variant.is_standard());
+    assert_eq!(variant.name, "Horde");
+
+    let position = shakmaty::fen::Fen::from_ascii(game.fen.as_bytes())
+        .expect("the fen itself is syntactically valid")
+        .into_position::<shakmaty::Chess>(shakmaty::CastlingMode::Standard);
+    assert!(
+        position.is_err(),
+        "a Horde position must not parse as standard chess"
+    );
+}
+
+/// A game with no `variant` field is standard, which is how the API omits it.
+#[test]
+fn missing_variant_is_treated_as_standard() {
+    let raw = r#"{
+      "fullId": "abcdefghijkl",
+      "gameId": "abcdefgh",
+      "fen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      "color": "white",
+      "opponent": {"id": "someone", "username": "someone", "rating": 1500},
+      "isMyTurn": true
+    }"#;
+
+    let game: OngoingGame = serde_json::from_str(raw).expect("decode");
+    assert!(game.variant.is_none());
+    assert_eq!(
+        chess_tui::lichess::models::unsupported_variant_name(game.variant.as_ref()),
+        None
+    );
+}

--- a/website/docs/Lichess/setup.md
+++ b/website/docs/Lichess/setup.md
@@ -134,9 +134,29 @@ If the file doesn't exist, create it with this content. Make sure to replace `YO
 
 By default `chess-tui` talks to the official Lichess API at `https://lichess.org/api`.
 
-You can point it at a different endpoint by setting the `CHESS_TUI_LICHESS_API_URL`
-environment variable. This is useful for self-hosted [lila](https://github.com/lichess-org/lila)
-instances, staging environments, or a local mock server used during development.
+You can point it at a different endpoint, which is useful for self-hosted
+[lila](https://github.com/lichess-org/lila) instances, staging environments, or a local
+mock server used during development.
+
+### From the TUI
+
+The API URL input is pre-filled with the URL currently in effect, so you only need to
+edit the part you want to change. It can be reached from two places:
+
+- **Before logging in** press `Tab` on the "Enter Lichess API Token" popup. The popup
+  shows the URL that your token will be validated against, so use this when your token
+  belongs to a server other than `lichess.org`. Anything you already typed into the
+  token field is kept while you edit the URL.
+- **After logging in** select **API URL** in the Lichess menu.
+
+Press `Enter` to save or `Esc` to cancel. The URL must start with `http://` or
+`https://`; submitting an empty input restores the default. The new URL applies
+immediately to every subsequent API request and is saved to `config.toml` as
+`lichess_api_url`, so it survives a restart.
+
+### From the environment
+
+Set the `CHESS_TUI_LICHESS_API_URL` environment variable:
 
 ```bash
 CHESS_TUI_LICHESS_API_URL="https://lichess.dev/api" chess-tui
@@ -153,8 +173,11 @@ Notes:
 
 - The value should be the API base URL, including the `/api` suffix if your instance uses one.
 - Trailing slashes are trimmed automatically.
-- If the variable is unset or empty, the default `https://lichess.org/api` is used.
-- The variable is read once at startup, so restart `chess-tui` after changing it.
+- The variable takes precedence over the value saved in `config.toml`, and is read once at
+  startup. Changing the URL from the TUI still applies for the rest of the session, but the
+  environment variable wins again on the next launch.
+- If the variable is unset or empty, the value from `config.toml` is used, falling back to
+  the default `https://lichess.org/api`.
 
 ## Verifying Your Setup
 

--- a/website/docs/Lichess/setup.md
+++ b/website/docs/Lichess/setup.md
@@ -130,6 +130,32 @@ lichess_token = "YOUR_LICHESS_TOKEN_HERE"
 
 If the file doesn't exist, create it with this content. Make sure to replace `YOUR_LICHESS_TOKEN_HERE` with your actual token.
 
+## Using a Custom API Endpoint
+
+By default `chess-tui` talks to the official Lichess API at `https://lichess.org/api`.
+
+You can point it at a different endpoint by setting the `CHESS_TUI_LICHESS_API_URL`
+environment variable. This is useful for self-hosted [lila](https://github.com/lichess-org/lila)
+instances, staging environments, or a local mock server used during development.
+
+```bash
+CHESS_TUI_LICHESS_API_URL="https://lichess.dev/api" chess-tui
+```
+
+Or export it for the whole shell session:
+
+```bash
+export CHESS_TUI_LICHESS_API_URL="http://localhost:9663/api"
+chess-tui
+```
+
+Notes:
+
+- The value should be the API base URL, including the `/api` suffix if your instance uses one.
+- Trailing slashes are trimmed automatically.
+- If the variable is unset or empty, the default `https://lichess.org/api` is used.
+- The variable is read once at startup, so restart `chess-tui` after changing it.
+
 ## Verifying Your Setup
 
 Once you've configured your token, you can verify it's working:

--- a/website/docs/Lichess/setup.md
+++ b/website/docs/Lichess/setup.md
@@ -154,6 +154,15 @@ Press `Enter` to save or `Esc` to cancel. The URL must start with `http://` or
 immediately to every subsequent API request and is saved to `config.toml` as
 `lichess_api_url`, so it survives a restart.
 
+### From the command line
+
+```bash
+chess-tui --lichess-api-url "https://lichess.dev/api"
+```
+
+Like `--lichess-token`, the value is written to `config.toml`, so later runs pick it up
+without the flag.
+
 ### From the environment
 
 Set the `CHESS_TUI_LICHESS_API_URL` environment variable:
@@ -172,12 +181,20 @@ chess-tui
 Notes:
 
 - The value should be the API base URL, including the `/api` suffix if your instance uses one.
-- Trailing slashes are trimmed automatically.
-- The variable takes precedence over the value saved in `config.toml`, and is read once at
-  startup. Changing the URL from the TUI still applies for the rest of the session, but the
-  environment variable wins again on the next launch.
-- If the variable is unset or empty, the value from `config.toml` is used, falling back to
-  the default `https://lichess.org/api`.
+- Trailing slashes and surrounding whitespace are trimmed automatically.
+- The variable is read once at startup, so restart `chess-tui` after changing it.
+
+### Precedence
+
+At startup the URL is taken from the first of these that is set:
+
+1. The `--lichess-api-url` command-line flag.
+2. The `CHESS_TUI_LICHESS_API_URL` environment variable.
+3. The `lichess_api_url` value in `config.toml`.
+4. The default, `https://lichess.org/api`.
+
+Changing the URL from the TUI applies immediately and is saved to `config.toml`, but a
+flag or environment variable still wins on the next launch.
 
 ## Verifying Your Setup
 

--- a/website/docs/Lichess/setup.md
+++ b/website/docs/Lichess/setup.md
@@ -180,7 +180,11 @@ chess-tui
 
 Notes:
 
-- The value should be the API base URL, including the `/api` suffix if your instance uses one.
+- The value must be the API base URL, ending in `/api` — that is where Lichess serves
+  its API. A URL like `https://lichess.example` answers on the web root but returns a
+  404 page for every API call, which is the most common cause of "cannot connect".
+  When you change the URL from the TUI, chess-tui warns about a missing `/api` and
+  offers to append it for you; you can still save the URL as typed.
 - Trailing slashes and surrounding whitespace are trimmed automatically.
 - The variable is read once at startup, so restart `chess-tui` after changing it.
 
@@ -195,6 +199,18 @@ At startup the URL is taken from the first of these that is set:
 
 Changing the URL from the TUI applies immediately and is saved to `config.toml`, but a
 flag or environment variable still wins on the next launch.
+
+### Tokens for a custom instance
+
+A token is only valid on the server that issued it, so a custom instance needs its own.
+Once the API URL is set, both the API URL popup and the token popup show a link to that
+instance's token page with the scopes chess-tui needs already ticked:
+
+```
+https://YOUR_INSTANCE/account/oauth/token/create?scopes[]=preference:read&scopes[]=board:play&scopes[]=challenge:write&scopes[]=puzzle:read&description=chess-tui
+```
+
+Open it in a browser, submit the form, and paste the token back into chess-tui.
 
 ## Verifying Your Setup
 
@@ -216,9 +232,15 @@ If you're having issues with your token:
 
 ### Common Error Messages
 
-- **"Invalid token"**: Your token may be incorrect or expired. Generate a new one.
-- **"Token missing permissions"**: Make sure you enabled all required scopes when generating the token.
-- **"Failed to fetch profile"**: Check your internet connection and try again.
+- **"The server rejected the token"** (HTTP 401): the token is wrong, expired, or was
+  issued by a different server than the configured API URL. Generate a new one from the
+  link in the token popup.
+- **"The token is missing a scope"** (HTTP 403): regenerate the token with
+  `preference:read`, `board:play`, `challenge:write`, and `puzzle:read` ticked.
+- **"The server has no such endpoint"** (HTTP 404): the API base URL is wrong. If it does
+  not end in `/api`, that is almost certainly the problem.
+- **"Could not open a connection"**: the host is unreachable from this machine — check
+  the host name, the port, and whether its TLS certificate is trusted here.
 
 ### Need Help?
 


### PR DESCRIPTION
# feat: support self-hosted Lichess instances

## Description

Hi! Thanks for this lovely piece of software. I got a little too bored one day and somehow ended up running Lichess's entire stack locally on some servers. I wanted to play games on it using this TUI but couldn't since the assumption of the Lichess API URL is hardcoded. I think it would be reasonable to allow for overriding this URL, but defaulting it to what it is right now (https://lichess.org/api).

That is the first half of this PR. Once the URL was configurable I actually pointed the TUI at my instance, and puzzles and games both broke, so the second half fixes what that turned up. Everything here is a no-op against lichess.org.

### Configurable API base URL

`LICHESS_API_URL` is resolved from the `CHESS_TUI_LICHESS_API_URL` environment variable, falling back to the previous value when the variable is unset or blank. Trailing slashes and surrounding whitespace are trimmed so call sites can keep appending `/some/path`. It can also be set with a `--lichess-api-url` flag, persisted in the config file, and edited from the TUI. Since a wrong base URL is now a thing that can happen, the error messages name the likely cause — a missing `/api` suffix, an unreachable host, a token the instance rejects.

### Puzzles: accept a payload with a FEN and no PGN

A self-hosted instance whose puzzle database has no game replay serves a different `/api/puzzle/next` payload than lichess.org:

| Field | lichess.org | self-hosted |
| --- | --- | --- |
| `game.clock` | present | absent |
| `game.pgn` | full PGN | empty string |
| `puzzle.fen` / `puzzle.lastMove` | absent | present |

`PuzzleGame` declared `clock` as a required `String`, so serde failed the decode before anything else ran and no puzzle would load. Making it optional is not enough on its own: `PuzzleGame::load` rebuilt the board solely by replaying the PGN, which would leave an empty-PGN puzzle sitting at the standard starting position with a solution that does not apply to it.

Both shapes are now accepted — replay the PGN when there is one, otherwise set the board straight from `puzzle.fen` using the same `Fen::from_ascii` / `into_position` pair `GameBoard::reconstruct_history` already uses. With neither, it fails with a message naming the puzzle rather than silently showing the wrong position.

Puzzle submission is reworked alongside it, as an explicit `PuzzleSubmitOutcome`. An instance can accept the submission and record nothing (returning `{"puzzles":[],"rounds":[]}`), or serve no puzzle-result endpoint at all; both now say so on the end screen instead of showing a permanent `+0 Elo`. The submitting thread also always sends an outcome — it previously dropped errors silently, which left the end screen on "Calculating Elo change..." forever. That last one is a bug against lichess.org too, not just against a self-hosted instance.

### Games: refuse non-standard variants rather than failing on their position

chess-tui models every position with `shakmaty::Chess`, but nothing read a game's `variant`. A Horde game in my ongoing-games list was offered like any other, and selecting it failed deep inside board setup — its FEN has no white king, so `into_position` rejects it, and its moves are illegal in standard chess from the first ply. All the user saw was a bare parse error with no hint that the variant was the problem.

`variant` is now read from the ongoing-games and event-stream payloads, unplayable games are marked in the list, and selecting one (or having one start) says which variant it is. A missing `variant` field means standard, which is how the API omits it. The FEN failure paths are kept as a backstop but now name the game and the FEN.

### Logging

Every failing call built a message with `transport_error` or `status_error`, returned it, and showed it in a popup — nothing was logged. A debug log of a failed puzzle fetch stopped dead after `Fetching puzzle from:` with no error line at all, and the popup text was gone the moment it was dismissed. Both the point where a message is built and the point where an error popup is shown now log it.

## How Has This Been Tested?

- `cargo test` — 135 tests pass. `cargo clippy --all-targets` reports no new warning classes.
- New `tests/lichess_puzzle_payload_tests.rs` covers both puzzle payload shapes, using responses captured verbatim from lichess.org and from a self-hosted instance: the FEN branch produces a one-position history matching the FEN, the PGN branch still replays all 62 moves, a payload with neither fails with a named error, and a Horde ongoing game is flagged while its FEN is confirmed unparseable as standard chess.
- Manually against a self-hosted instance: a puzzle loads, the board is set from the FEN with the correct side to move, and the first solution move resolves to the right square. Submission is reported as unrecorded rather than as a failure.
- Manually against lichess.org: puzzles still load through the PGN path and the default base URL is unchanged when `CHESS_TUI_LICHESS_API_URL` is unset.

Happy to split this into two PRs if you would rather review the URL override on its own.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
